### PR TITLE
fix ch32fun directory reference in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ minichlink/minichlink
 minichlink/minichlink.so
 compile_commands.json
 .cache
-ch32v003fun/generated_*.ld
+ch32fun/generated_*.ld


### PR DESCRIPTION
seems like this was missed in #506 