### PR TITLE
Fix PLL_MULTIPLICATION definition for ch32v303

### DIFF
--- a/ch32fun/ch32v30xhw.h
+++ b/ch32fun/ch32v30xhw.h
@@ -10436,7 +10436,7 @@ typedef struct
 				#define PLL_MULTIPLICATION RCC_PLLMULL15
 			#elif FUNCONF_PLL_MULTIPLIER == 16
 				#define PLL_MULTIPLICATION RCC_PLLMULL16
-			#elif defined(CH32V20x) && FUNCONF_PLL_MULTIPLIER == 18
+			#elif FUNCONF_PLL_MULTIPLIER == 18
 				#define PLL_MULTIPLICATION RCC_PLLMULL18
 			#else
 				#error "Invalid PLL multiplier"


### PR DESCRIPTION
The problem I noticed in #498 was only partially solved by 5ec73e145b374778156b2ef0a5c99666ae95417c: there is still a condition checking only for ch32v20x before setting `PLL_MULTIPLICATION`.

As this file is only included when using a ch32v30x I just removed the check. 