### PR TITLE
CH59x SysTick IRQ example

### DIFF
--- a/ch32fun/ch59xhw.h
+++ b/ch32fun/ch59xhw.h
@@ -142,15 +142,15 @@ typedef struct
 #define	NVIC_KEY3		           ((uint32_t)0xBEEF0000)
 
 #define SysTick                    ((SysTick_Type *) SysTick_BASE)
-#define SysTick_LOAD_RELOAD_Msk    (0xFFFFFFFFFFFFFFFF)
-#define SysTick_CTLR_SWIE          (1 << 31)
-#define SysTick_CTLR_INIT          (1 << 5)
-#define SysTick_CTLR_MODE          (1 << 4)
-#define SysTick_CTLR_STRE          (1 << 3)
-#define SysTick_CTLR_STCLK         (1 << 2)
-#define SysTick_CTLR_STIE          (1 << 1)
-#define SysTick_CTLR_STE           (1 << 0)
-#define SysTick_SR_CNTIF           (1 << 0)
+#define SYSTICK_LOAD_RELOAD_MSK    (0xFFFFFFFFFFFFFFFF)
+#define SYSTICK_CTLR_SWIE          (1 << 31)
+#define SYSTICK_CTLR_INIT          (1 << 5)
+#define SYSTICK_CTLR_MODE          (1 << 4)
+#define SYSTICK_CTLR_STRE          (1 << 3)
+#define SYSTICK_CTLR_STCLK         (1 << 2)
+#define SYSTICK_CTLR_STIE          (1 << 1)
+#define SYSTICK_CTLR_STE           (1 << 0)
+#define SYSTICK_SR_CNTIF           (1 << 0)
 
 typedef enum
 {

--- a/examples_ch59x/systick_irq/Makefile
+++ b/examples_ch59x/systick_irq/Makefile
@@ -1,0 +1,10 @@
+all : flash
+
+TARGET:=systick_irq
+TARGET_MCU:=CH592
+TARGET_MCU_PACKAGE:=CH592F
+
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean

--- a/examples_ch59x/systick_irq/funconfig.h
+++ b/examples_ch59x/systick_irq/funconfig.h
@@ -1,0 +1,14 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define FUNCONF_USE_HSI           0 // CH592 does not have HSI
+#define FUNCONF_USE_HSE           1
+#define CLK_SOURCE_CH59X          CLK_SOURCE_PLL_60MHz // default so not really needed
+#define FUNCONF_SYSTEM_CORE_CLOCK 60 * 1000 * 1000     // keep in line with CLK_SOURCE_CH59X
+
+#define FUNCONF_DEBUG_HARDFAULT   0
+#define FUNCONF_USE_CLK_SEC       0
+#define FUNCONF_USE_DEBUGPRINTF   0 // saves 16 bytes, enable / remove if you want printf over swio
+#define FUNCONF_INIT_ANALOG       0 // ADC is not implemented yet
+
+#endif

--- a/examples_ch59x/systick_irq/systick_irq.c
+++ b/examples_ch59x/systick_irq/systick_irq.c
@@ -1,0 +1,63 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+// Number of ticks elapsed per millisecond
+#define SYSTICK_ONE_MILLISECOND ((uint32_t)FUNCONF_SYSTEM_CORE_CLOCK / 1000)
+
+#define LED      PA8
+#define INTERVAL 300*SYSTICK_ONE_MILLISECOND
+
+/*
+ * Initialises the SysTick to trigger an IRQ with auto-reload, using HCLK/1 as
+ * its clock source
+ */
+void systick_init(void)
+{
+	// Reset any pre-existing configuration
+	SysTick->CTLR = 0x0000;
+	
+	// Set the compare register to trigger once in 300 milliseconds
+	SysTick->CMP = INTERVAL;
+
+	// Reset the Count Register, and the global millis counter to 0
+	SysTick->CNT = 0x00000000;
+	
+	// Set the SysTick Configuration
+	// NOTE: By not setting SYSTICK_CTLR_STRE, we maintain compatibility with
+	// busywait delay funtions used by ch32v003_fun.
+	SysTick->CTLR |= SYSTICK_CTLR_STE   |  // Enable Counter
+	                 SYSTICK_CTLR_STIE  |  // Enable Interrupts
+	                 SYSTICK_CTLR_STCLK ;  // Set Clock Source to HCLK/1
+	
+	// Enable the SysTick IRQ
+	NVIC_EnableIRQ(SysTicK_IRQn);
+}
+
+/*
+ * SysTick ISR - must be lightweight to prevent the CPU from bogging down.
+ * Increments Compare Register and systick_millis when triggered (every 1ms)
+ * NOTE: the `__attribute__((interrupt))` attribute is very important
+ */
+void SysTick_Handler(void) __attribute__((interrupt));
+void SysTick_Handler(void)
+{
+	// Increment CMP for the next trigger
+	SysTick->CMP += INTERVAL;
+
+	// Clear the trigger state for the next IRQ
+	SysTick->SR = 0x00000000;
+
+	// Flip the gpio (GPIO_InverseBits is a ch5xx specific macro)
+	GPIO_InverseBits(LED);
+}
+
+
+int main(void)
+{
+	SystemInit();
+	systick_init();
+	
+	funPinMode(LED, GPIO_CFGLR_OUT_2Mhz_PP);
+		
+	while(1);
+}


### PR DESCRIPTION
Example how to use SysTick on CH59x to generate periodic interrupts for timing.