### PR TITLE
[PROPOSAL] Set machine mode at startup

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1128,10 +1128,10 @@ void handle_reset( void )
 	csrw 0xbc0, t0\n"
 
 #if defined(CH32V30x) && !defined( DISABLED_FLOAT )
-"	li t0, 0x6088\n\
+"	li t0, 0x7888\n\
 	csrs mstatus, t0\n"
 #else
-"	li t0, 0x88\n\
+"	li t0, 0x1888\n\
 	csrs mstatus, t0\n"
 #endif
 

--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1018,12 +1018,12 @@ void handle_reset( void )
 	// Setup the interrupt vector, processor status and INTSYSCR.
 
 #if FUNCONF_ENABLE_HPE	// Enabled nested and hardware (HPE) stack, since it's really good on the x035.
-"	li t0, 0x88\n\
+"	li t0, 0x1888\n\
 	csrs mstatus, t0\n"
 "	li t0, 0x0b\n\
 	csrw 0x804, t0\n"
 #else
-"	li a0, 0x80\n\
+"	li a0, 0x1880\n\
 	csrw mstatus, a0\n"
 #endif
 "	li a3, 0x3\n\


### PR DESCRIPTION
The current way `mstatus` being initialized prevents us from manipulation of `mtvec` register. If you want to make your own custom bootloader, you need to alter `mtvec` right after the bootloader loads your firmware.

For example, i have my booloader starting from `0x08000000`:

```c
#define MAIN_CODE_ADDR (0x400);

int main()
{ 
    SystemInit();

    doSomeBootloaderStuffHere();

    void (*jump_func)(void) ;

    jump_func = (void (*)(void))MAIN_CODE_ADDR;

    jump_func(); 
}
```

Then my main firmware, which lives in `0x08000400`, takes control. The main firmware has its own startup code, so it tries to alter the mtvec register. If MCU is set to user mode in bootloader startup, i get a hardfault. If i initialize `mstatus` in the proposed way, everything works fine.

So my proposal is not to use user mode at all, but use machine node instead. Maybe, we should make this behaviour configurable in `funconfig.h`?