### PR TITLE
CH59x fix UART long printf issue #565

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -1307,6 +1307,7 @@ WEAK int _write(int fd, const char *buf, int size)
 {
 	for(int i = 0; i < size; i++){
 #if defined(CH59x)
+		while(!(R8_UART1_LSR & RB_LSR_TX_ALL_EMP));
 		R8_UART1_THR = buf[i];
 #else
 		while( !(USART1->STATR & USART_FLAG_TC));
@@ -1320,6 +1321,7 @@ WEAK int _write(int fd, const char *buf, int size)
 WEAK int putchar(int c)
 {
 #if defined(CH59x)
+	while(!(R8_UART1_LSR & RB_LSR_TX_ALL_EMP));
 	R8_UART1_THR = c;
 #else
 	while( !(USART1->STATR & USART_FLAG_TC));

--- a/examples_ch59x/uartdemo/uartdemo.c
+++ b/examples_ch59x/uartdemo/uartdemo.c
@@ -8,7 +8,7 @@ int main()
 	funPinMode( PB22, GPIO_CFGLR_IN_PU );
 
 	SetupUART(FUNCONF_UART_PRINTF_BAUD); // UART1 on rx,tx:PA8,PA9 at 115200 baud
-	printf("PA9 tx\r\n");
+	printf("TX in on PA9, RX is on PA8 but not implemented in this demo.\r\n");
 
 	u8 i = 0;
 	char msg[] = "ch32fun is awesome!\r\n";


### PR DESCRIPTION
For uart tx we should wait for the buffer to be empty so we don't risk overfilling it and dropping characters.