### PR TITLE
Fixed ch32v003 random number example with native Linux and screen.

### DIFF
--- a/examples/random_numbers/funconfig.h
+++ b/examples/random_numbers/funconfig.h
@@ -4,5 +4,9 @@
 #define RANDOM_STRENGTH    2
 #define CH32V003           1
 
+#define FUNCONF_USE_DEBUGPRINTF 0
+#define FUNCONF_USE_UARTPRINTF  1
+#define FUNCONF_UART_PRINTF_BAUD 115200
+
 #endif
 

--- a/examples/random_numbers/random_numbers.c
+++ b/examples/random_numbers/random_numbers.c
@@ -48,7 +48,7 @@ int main()
 	// * 3045866432
 	for(uint8_t x = 0; x < 4; x++)
 	{
-		printf("Random Number %u: %lu\n", x, rand());
+		printf("Random Number %u: %lu\n\r", x, rand());
 	}
 
 	// Seeding the LFSR using a semi-random input, like a timer tick, or 


### PR DESCRIPTION
Just started working with this library yesterday, but wanted to throw up a PR for this in case what I have found is a problem and not the norm.

I'm running Ubuntu 24 native, trying to program the CH32V003F4P6, using screen as my tty uART utility.  What I found was that the header definitions in the "random number" example didn't work as described, and I had to modify them to be more in line with the uartdemo header definitions.  Additionally, simply returning a newline character resulted in suboptimal output from screen for me, which was rectified by switching to a newline followed by a carriage return character.

I am fairly positive that these are all things that people have dealt with, cause this is a fairly popular library and a fairly popular MCU, but I at least wanted to get my opinions out while they were fresh on my mind in case they were valuable.  Feel free to tell me I'm dumb and close this as a no fix, I won't be offended.