### PR TITLE
Cleanup 003 with thing noticed when making 00x

### DIFF
--- a/ch32fun/ch32v003hw.h
+++ b/ch32fun/ch32v003hw.h
@@ -209,6 +209,19 @@ typedef struct
 	__IO uint32_t UNIID3;
 } ESIG_TypeDef;
 
+typedef struct
+{
+    union
+    {
+        __I uint32_t CHIPID;
+        struct
+        {
+            __I uint16_t REVID;
+          __I uint16_t DEVID;
+        };
+    };
+} INFO_TypeDef;
+
 /* General Purpose I/O */
 typedef enum
 {
@@ -2142,14 +2155,14 @@ typedef struct
 #define TIM_CC4OF                               ((uint16_t)0x1000) /* Capture/Compare 4 Overcapture Flag */
 
 /*******************  Bit definition for TIM_SWEVGR register  ********************/
-#define TIM_UG                                  ((uint8_t)0x01) /* Update Generation */
-#define TIM_CC1G                                ((uint8_t)0x02) /* Capture/Compare 1 Generation */
-#define TIM_CC2G                                ((uint8_t)0x04) /* Capture/Compare 2 Generation */
-#define TIM_CC3G                                ((uint8_t)0x08) /* Capture/Compare 3 Generation */
-#define TIM_CC4G                                ((uint8_t)0x10) /* Capture/Compare 4 Generation */
-#define TIM_COMG                                ((uint8_t)0x20) /* Capture/Compare Control Update Generation */
-#define TIM_TG                                  ((uint8_t)0x40) /* Trigger Generation */
-#define TIM_BG                                  ((uint8_t)0x80) /* Break Generation */
+#define TIM_UG                                  ((uint16_t)0x0001) /* Update Generation */
+#define TIM_CC1G                                ((uint16_t)0x0002) /* Capture/Compare 1 Generation */
+#define TIM_CC2G                                ((uint16_t)0x0004) /* Capture/Compare 2 Generation */
+#define TIM_CC3G                                ((uint16_t)0x0008) /* Capture/Compare 3 Generation */
+#define TIM_CC4G                                ((uint16_t)0x0010) /* Capture/Compare 4 Generation */
+#define TIM_COMG                                ((uint16_t)0x0020) /* Capture/Compare Control Update Generation */
+#define TIM_TG                                  ((uint16_t)0x0040) /* Trigger Generation */
+#define TIM_BG                                  ((uint16_t)0x0080) /* Break Generation */
 
 /******************  Bit definition for TIM_CHCTLR1 register  *******************/
 #define TIM_CC1S                                ((uint16_t)0x0003) /* CC1S[1:0] bits (Capture/Compare 1 Selection) */
@@ -2279,16 +2292,20 @@ typedef struct
 #define TIM_REP                                 ((uint8_t)0xFF) /* Repetition Counter Value */
 
 /*******************  Bit definition for TIM_CH1CVR register  *******************/
-#define TIM_CCR1                                ((uint16_t)0xFFFF) /* Capture/Compare 1 Value */
+#define TIM_CCR1                                ((uint32_t)0x0000FFFF) /* Capture/Compare 1 Value */
+#define TIM_CH1CVR_LEVEL1                       ((uint32_t)0x00010000) /* The level indication bit corresponding to the captured value */
 
 /*******************  Bit definition for TIM_CH2CVR register  *******************/
-#define TIM_CCR2                                ((uint16_t)0xFFFF) /* Capture/Compare 2 Value */
+#define TIM_CCR2                                ((uint32_t)0x0000FFFF) /* Capture/Compare 2 Value */
+#define TIM_CH2CVR_LEVEL2                       ((uint32_t)0x00010000) /* The level indication bit corresponding to the captured value */
 
 /*******************  Bit definition for TIM_CH3CVR register  *******************/
-#define TIM_CCR3                                ((uint16_t)0xFFFF) /* Capture/Compare 3 Value */
+#define TIM_CCR3                                ((uint32_t)0x0000FFFF) /* Capture/Compare 3 Value */
+#define TIM_CH3CVR_LEVEL3                       ((uint32_t)0x00010000) /* The level indication bit corresponding to the captured value */
 
 /*******************  Bit definition for TIM_CH4CVR register  *******************/
-#define TIM_CCR4                                ((uint16_t)0xFFFF) /* Capture/Compare 4 Value */
+#define TIM_CCR4                                ((uint32_t)0x0000FFFF) /* Capture/Compare 4 Value */
+#define TIM_CH4CVR_LEVEL4                       ((uint32_t)0x00010000) /* The level indication bit corresponding to the captured value */
 
 /*******************  Bit definition for TIM_BDTR register  *******************/
 #define TIM_DTG                                 ((uint16_t)0x00FF) /* DTG[0:7] bits (Dead-Time Generator set-up) */

--- a/ch32fun/ch32v003hw.h
+++ b/ch32fun/ch32v003hw.h
@@ -139,19 +139,6 @@ typedef struct
     __IO uint32_t DLYR;
 } ADC_TypeDef;
 
-
-
-/* CRC Calculation Unit */
-typedef struct
-{
-	__IO uint32_t DATAR;
-	__IO uint8_t  IDATAR;
-	uint8_t       RESERVED0;
-	uint16_t      RESERVED1;
-	__IO uint32_t CTLR;
-} CRC_TypeDef;
-
-
 /* Debug MCU */
 typedef struct
 {
@@ -214,28 +201,13 @@ typedef struct
 
 typedef struct
 {
-	__IO uint16_t CAP;
+	__IO uint16_t FLACAP;
 	__IO uint16_t RES1;
 	__IO uint32_t RES2;
-	__IO uint32_t UID0;
-	__IO uint32_t UID1;
-	__IO uint32_t UID2;
-	__IO uint32_t RES3;
-} ESG_TypeDef;
-
-typedef struct
-{
-    union
-    {   
-        __I uint32_t CHIPID;
-        struct 
-        {
-            __I uint16_t REVID;
-	        __I uint16_t DEVID;
-        };
-    };
-} INFO_TypeDef;
-
+	__IO uint32_t UNIID1;
+	__IO uint32_t UNIID2;
+	__IO uint32_t UNIID3;
+} ESIG_TypeDef;
 
 /* General Purpose I/O */
 typedef enum
@@ -501,28 +473,23 @@ typedef struct
 /* Universal Synchronous Asynchronous Receiver Transmitter */
 typedef struct
 {
-    __IO uint16_t STATR;
-    uint16_t      RESERVED0;
-    __IO uint16_t DATAR;
-    uint16_t      RESERVED1;
-    __IO uint16_t BRR;
-    uint16_t      RESERVED2;
-    __IO uint16_t CTLR1;
-    uint16_t      RESERVED3;
-    __IO uint16_t CTLR2;
-    uint16_t      RESERVED4;
-    __IO uint16_t CTLR3;
-    uint16_t      RESERVED5;
-    __IO uint16_t GPR;
-    uint16_t      RESERVED6;
+    __IO uint32_t STATR;
+    __IO uint32_t DATAR;
+    __IO uint32_t BRR;
+    __IO uint32_t CTLR1;
+    __IO uint32_t CTLR2;
+    __IO uint32_t CTLR3;
+    __IO uint32_t GPR;
 } USART_TypeDef;
 
 /* Window WatchDog */
 typedef struct
 {
-    __IO uint32_t CTLR;
-    __IO uint32_t CFGR;
-    __IO uint32_t STATR;
+    __IO uint16_t CTLR;
+    uint16_t      RESERVED1;
+    __IO uint16_t CFGR;
+    uint16_t      RESERVED2;
+    __IO uint16_t STATR;
 } WWDG_TypeDef;
 
 /* Enhanced Registers */
@@ -530,17 +497,6 @@ typedef struct
 {
     __IO uint32_t EXTEN_CTR;
 } EXTEN_TypeDef;
-
-/* The reference manual for the ch32v2xx/v3xx reference this as "CTR" field in the "EXTEND" register so adding an alias here. */
-typedef struct
-{
-    __IO uint32_t CTR;
-} EXTEND_TypeDef;
-
-
-
-
-
 
 #endif
 
@@ -636,7 +592,7 @@ typedef struct
 #define RCC                                     ((RCC_TypeDef *)RCC_BASE)
 #define FLASH                                   ((FLASH_TypeDef *)FLASH_R_BASE)
 #define OB                                      ((OB_TypeDef *)OB_BASE)
-#define ESIG                                    ((ESG_TypeDef *)ESIG_BASE)
+#define ESIG                                    ((ESIG_TypeDef *)ESIG_BASE)
 // Mentioned in ch32v30x_dbgmcu.c, may not work on all processors.
 #define INFO                                    ((INFO_TypeDef *)INFO_BASE) 
 #define EXTEN                                   ((EXTEN_TypeDef *)EXTEN_BASE)
@@ -654,11 +610,11 @@ typedef struct
 /******************************************************************************/
 
 /********************  Bit definition for ADC_STATR register  ********************/
-#define ADC_AWD                                 ((uint8_t)0x01) /* Analog watchdog flag */
-#define ADC_EOC                                 ((uint8_t)0x02) /* End of conversion */
-#define ADC_JEOC                                ((uint8_t)0x04) /* Injected channel end of conversion */
-#define ADC_JSTRT                               ((uint8_t)0x08) /* Injected channel Start flag */
-#define ADC_STRT                                ((uint8_t)0x10) /* Regular channel Start flag */
+#define ADC_AWD                                 ((uint32_t)0x00000001) /* Analog watchdog flag */
+#define ADC_EOC                                 ((uint32_t)0x00000002) /* End of conversion */
+#define ADC_JEOC                                ((uint32_t)0x00000004) /* Injected channel end of conversion */
+#define ADC_JSTRT                               ((uint32_t)0x00000008) /* Injected channel Start flag */
+#define ADC_STRT                                ((uint32_t)0x00000010) /* Regular channel Start flag */
 
 /*******************  Bit definition for ADC_CTLR1 register  ********************/
 #define ADC_AWDCH                               ((uint32_t)0x0000001F) /* AWDCH[4:0] bits (Analog watchdog channel select bits) */
@@ -681,12 +637,6 @@ typedef struct
 #define ADC_DISCNUM_0                           ((uint32_t)0x00002000) /* Bit 0 */
 #define ADC_DISCNUM_1                           ((uint32_t)0x00004000) /* Bit 1 */
 #define ADC_DISCNUM_2                           ((uint32_t)0x00008000) /* Bit 2 */
-
-#define ADC_DUALMOD                             ((uint32_t)0x000F0000) /* DUALMOD[3:0] bits (Dual mode selection) */
-#define ADC_DUALMOD_0                           ((uint32_t)0x00010000) /* Bit 0 */
-#define ADC_DUALMOD_1                           ((uint32_t)0x00020000) /* Bit 1 */
-#define ADC_DUALMOD_2                           ((uint32_t)0x00040000) /* Bit 2 */
-#define ADC_DUALMOD_3                           ((uint32_t)0x00080000) /* Bit 3 */
 
 #define ADC_JAWDEN                              ((uint32_t)0x00400000) /* Analog watchdog enable on injected channels */
 #define ADC_AWDEN                               ((uint32_t)0x00800000) /* Analog watchdog enable on regular channels */
@@ -812,22 +762,22 @@ typedef struct
 #define ADC_SMP9_2                              ((uint32_t)0x20000000) /* Bit 2 */
 
 /******************  Bit definition for ADC_IOFR1 register  *******************/
-#define ADC_JOFFSET1                            ((uint16_t)0x0FFF) /* Data offset for injected channel 1 */
+#define ADC_JOFFSET1                            ((uint32_t)0x000002FF) /* Data offset for injected channel 1 */
 
 /******************  Bit definition for ADC_IOFR2 register  *******************/
-#define ADC_JOFFSET2                            ((uint16_t)0x0FFF) /* Data offset for injected channel 2 */
+#define ADC_JOFFSET2                            ((uint32_t)0x000002FF) /* Data offset for injected channel 2 */
 
 /******************  Bit definition for ADC_IOFR3 register  *******************/
-#define ADC_JOFFSET3                            ((uint16_t)0x0FFF) /* Data offset for injected channel 3 */
+#define ADC_JOFFSET3                            ((uint32_t)0x000002FF) /* Data offset for injected channel 3 */
 
 /******************  Bit definition for ADC_IOFR4 register  *******************/
-#define ADC_JOFFSET4                            ((uint16_t)0x0FFF) /* Data offset for injected channel 4 */
+#define ADC_JOFFSET4                            ((uint32_t)0x000002FF) /* Data offset for injected channel 4 */
 
 /*******************  Bit definition for ADC_WDHTR register  ********************/
-#define ADC_HT                                  ((uint16_t)0x0FFF) /* Analog watchdog high threshold */
+#define ADC_HT                                  ((uint32_t)0x000002FF) /* Analog watchdog high threshold */
 
 /*******************  Bit definition for ADC_WDLTR register  ********************/
-#define ADC_LT                                  ((uint16_t)0x0FFF) /* Analog watchdog low threshold */
+#define ADC_LT                                  ((uint32_t)0x000002FF) /* Analog watchdog low threshold */
 
 /*******************  Bit definition for ADC_RSQR1 register  *******************/
 #define ADC_SQ13                                ((uint32_t)0x0000001F) /* SQ13[4:0] bits (13th conversion in regular sequence) */
@@ -984,24 +934,24 @@ typedef struct
 #define ADC_JL_1                                ((uint32_t)0x00200000) /* Bit 1 */
 
 /*******************  Bit definition for ADC_IDATAR1 register  *******************/
-#define ADC_IDATAR1_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+#define ADC_IDATAR1_JDATA                       ((uint32_t)0x0000FFFF) /* Injected data */
 
 /*******************  Bit definition for ADC_IDATAR2 register  *******************/
-#define ADC_IDATAR2_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+#define ADC_IDATAR2_JDATA                       ((uint32_t)0x0000FFFF) /* Injected data */
 
 /*******************  Bit definition for ADC_IDATAR3 register  *******************/
-#define ADC_IDATAR3_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+#define ADC_IDATAR3_JDATA                       ((uint32_t)0x0000FFFF) /* Injected data */
 
 /*******************  Bit definition for ADC_IDATAR4 register  *******************/
-#define ADC_IDATAR4_JDATA                       ((uint16_t)0xFFFF) /* Injected data */
+#define ADC_IDATAR4_JDATA                       ((uint32_t)0x0000FFFF) /* Injected data */
 
 /********************  Bit definition for ADC_RDATAR register  ********************/
 #define ADC_RDATAR_DATA                         ((uint32_t)0x0000FFFF) /* Regular data */
 #define ADC_RDATAR_ADC2DATA                     ((uint32_t)0xFFFF0000) /* ADC2 data */
 
 /********************  Bit definition for ADC_DLYR register  ********************/
-#define ADC_DLYR_DLYVLU                         ((uint32_t)0x1FF) 
-#define ADC_DLYR_DLYSRC                         ((uint32_t)0x200) 
+#define ADC_DLYR_DLYVLU                         ((uint32_t)0x000001FF) 
+#define ADC_DLYR_DLYSRC                         ((uint32_t)0x00000200) 
 
 /******************************************************************************/
 /*                             DMA Controller                                 */
@@ -1393,47 +1343,45 @@ typedef struct
 #define FLASH_OBKEYR_OBKEYR                     ((uint32_t)0xFFFFFFFF) /* Option Byte Key */
 
 /******************  Bit definition for FLASH_STATR register  *******************/
-#define FLASH_STATR_BSY                         ((uint8_t)0x01) /* Busy */
-#define FLASH_STATR_WRPRTERR                    ((uint8_t)0x10) /* Write Protection Error */
-#define FLASH_STATR_EOP                         ((uint8_t)0x20) /* End of operation */
-#define FLASH_STATR_MODE                        ((uint16_t)0x4000)
-#define FLASH_STATR_LOCK                        ((uint16_t)0x8000)
+#define FLASH_STATR_BSY                         ((uint32_t)0x00000001) /* Busy */
+#define FLASH_STATR_WRPRTERR                    ((uint32_t)0x00000010) /* Write Protection Error */
+#define FLASH_STATR_EOP                         ((uint32_t)0x00000020) /* End of operation */
+#define FLASH_STATR_MODE                        ((uint32_t)0x00004000)
+#define FLASH_STATR_LOCK                        ((uint32_t)0x00008000)
 
 /*******************  Bit definition for FLASH_CTLR register  *******************/
-#define FLASH_CTLR_PG                           (0x0001)     /* Programming */
-#define FLASH_CTLR_PER                          (0x0002)     /* Page Erase 1KByte*/
-#define FLASH_CTLR_MER                          (0x0004)     /* Mass Erase */
-#define FLASH_CTLR_OPTPG                        (0x0010)     /* Option Byte Programming */
-#define FLASH_CTLR_OPTER                        (0x0020)     /* Option Byte Erase */
-#define FLASH_CTLR_STRT                         (0x0040)     /* Start */
-#define FLASH_CTLR_LOCK                         (0x0080)     /* Lock */
-#define FLASH_CTLR_OPTWRE                       (0x0200)     /* Option Bytes Write Enable */
-#define FLASH_CTLR_ERRIE                        (0x0400)     /* Error Interrupt Enable */
-#define FLASH_CTLR_EOPIE                        (0x1000)     /* End of operation interrupt enable */
-#define FLASH_CTLR_FLOCK                        (0x8000)
-#define FLASH_CTLR_PAGE_PG                      (0x00010000) /* Page Programming 64Byte */
-#define FLASH_CTLR_PAGE_ER                      (0x00020000) /* Page Erase 64Byte */
-#define FLASH_CTLR_BUF_LOAD                     (0x00040000) /* Buffer Load */
-#define FLASH_CTLR_BUF_RST                      (0x00080000) /* Buffer Reset */
+#define FLASH_CTLR_PG                           ((uint32_t)0x00000001) /* Programming */
+#define FLASH_CTLR_PER                          ((uint32_t)0x00000002) /* Page Erase 1KByte*/
+#define FLASH_CTLR_MER                          ((uint32_t)0x00000004) /* Mass Erase */
+#define FLASH_CTLR_OPTPG                        ((uint32_t)0x00000010) /* Option Byte Programming */
+#define FLASH_CTLR_OPTER                        ((uint32_t)0x00000020) /* Option Byte Erase */
+#define FLASH_CTLR_STRT                         ((uint32_t)0x00000040) /* Start */
+#define FLASH_CTLR_LOCK                         ((uint32_t)0x00000080) /* Lock */
+#define FLASH_CTLR_OPTWRE                       ((uint32_t)0x00000200) /* Option Bytes Write Enable */
+#define FLASH_CTLR_ERRIE                        ((uint32_t)0x00000400) /* Error Interrupt Enable */
+#define FLASH_CTLR_EOPIE                        ((uint32_t)0x00001000) /* End of operation interrupt enable */
+#define FLASH_CTLR_FLOCK                        ((uint32_t)0x00008000)
+#define FLASH_CTLR_PAGE_PG                      ((uint32_t)0x00010000) /* Page Programming 64Byte */
+#define FLASH_CTLR_PAGE_ER                      ((uint32_t)0x00020000) /* Page Erase 64Byte */
+#define FLASH_CTLR_BUF_LOAD                     ((uint32_t)0x00040000) /* Buffer Load */
+#define FLASH_CTLR_BUF_RST                      ((uint32_t)0x00080000) /* Buffer Reset */
 
 /*******************  Bit definition for FLASH_ADDR register  *******************/
 #define FLASH_ADDR_FAR                          ((uint32_t)0xFFFFFFFF) /* Flash Address */
 
 /******************  Bit definition for FLASH_OBR register  *******************/
-#define FLASH_OBR_OPTERR                        ((uint16_t)0x0001) /* Option Byte Error */
-#define FLASH_OBR_RDPRT                         ((uint16_t)0x0002) /* Read protection */
+#define FLASH_OBR_OPTERR                        ((uint32_t)0x00000001) /* Option Byte Error */
+#define FLASH_OBR_RDPRT                         ((uint32_t)0x00000002) /* Read protection */
 
-#define FLASH_OBR_USER                          ((uint16_t)0x03FC) /* User Option Bytes */
-#define FLASH_OBR_WDG_SW                        ((uint16_t)0x0004) /* WDG_SW */
-#define FLASH_OBR_nRST_STOP                     ((uint16_t)0x0008) /* nRST_STOP */
-#define FLASH_OBR_STANDY_RST                    ((uint16_t)0x0010)
-#define FLASH_OBR_nRST_STDBY                    ((uint16_t)0x0010) /* nRST_STDBY */
-#define FLASH_OBR_RST_MODE                      ((uint16_t)0x0060) /* RST_MODE */
-#define FLASH_OBR_STATR_MODE                    ((uint16_t)0x0080)
-#define FLASH_OBR_FIX_11                        ((uint16_t)0x0300)
+#define FLASH_OBR_USER                          ((uint32_t)0x000003FC) /* User Option Bytes */
+#define FLASH_OBR_WDG_SW                        ((uint32_t)0x00000004) /* WDG_SW */
+#define FLASH_OBR_STANDY_RST                    ((uint32_t)0x00000010)
+#define FLASH_OBR_RST_MODE                      ((uint32_t)0x00000060) /* RST_MODE */
+#define FLASH_OBR_STATR_MODE                    ((uint32_t)0x00000080)
+#define FLASH_OBR_FIX_11                        ((uint32_t)0x00000300)
 
 /******************  Bit definition for FLASH_WPR register  ******************/
-#define FLASH_WPR_WRP                           ((uint32_t)0xFFFFFFFF) /* Write Protect */
+#define FLASH_WPR_WRP                           ((uint32_t)0x0000FFFF) /* Write Protect */
 
 /******************  Bit definition for FLASH_RDPR register  *******************/
 #define FLASH_RDPR_RDPR                         ((uint32_t)0x000000FF) /* Read protection option byte */
@@ -1540,110 +1488,25 @@ typedef struct
 #define GPIO_CFGLR_CNF7_0                       ((uint32_t)0x40000000) /* Bit 0 */
 #define GPIO_CFGLR_CNF7_1                       ((uint32_t)0x80000000) /* Bit 1 */
 
-/*******************  Bit definition for GPIO_CFGHR register  *******************/
-#define GPIO_CFGHR_MODE                         ((uint32_t)0x33333333) /* Port x mode bits */
-
-#define GPIO_CFGHR_MODE8                        ((uint32_t)0x00000003) /* MODE8[1:0] bits (Port x mode bits, pin 8) */
-#define GPIO_CFGHR_MODE8_0                      ((uint32_t)0x00000001) /* Bit 0 */
-#define GPIO_CFGHR_MODE8_1                      ((uint32_t)0x00000002) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE9                        ((uint32_t)0x00000030) /* MODE9[1:0] bits (Port x mode bits, pin 9) */
-#define GPIO_CFGHR_MODE9_0                      ((uint32_t)0x00000010) /* Bit 0 */
-#define GPIO_CFGHR_MODE9_1                      ((uint32_t)0x00000020) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE10                       ((uint32_t)0x00000300) /* MODE10[1:0] bits (Port x mode bits, pin 10) */
-#define GPIO_CFGHR_MODE10_0                     ((uint32_t)0x00000100) /* Bit 0 */
-#define GPIO_CFGHR_MODE10_1                     ((uint32_t)0x00000200) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE11                       ((uint32_t)0x00003000) /* MODE11[1:0] bits (Port x mode bits, pin 11) */
-#define GPIO_CFGHR_MODE11_0                     ((uint32_t)0x00001000) /* Bit 0 */
-#define GPIO_CFGHR_MODE11_1                     ((uint32_t)0x00002000) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE12                       ((uint32_t)0x00030000) /* MODE12[1:0] bits (Port x mode bits, pin 12) */
-#define GPIO_CFGHR_MODE12_0                     ((uint32_t)0x00010000) /* Bit 0 */
-#define GPIO_CFGHR_MODE12_1                     ((uint32_t)0x00020000) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE13                       ((uint32_t)0x00300000) /* MODE13[1:0] bits (Port x mode bits, pin 13) */
-#define GPIO_CFGHR_MODE13_0                     ((uint32_t)0x00100000) /* Bit 0 */
-#define GPIO_CFGHR_MODE13_1                     ((uint32_t)0x00200000) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE14                       ((uint32_t)0x03000000) /* MODE14[1:0] bits (Port x mode bits, pin 14) */
-#define GPIO_CFGHR_MODE14_0                     ((uint32_t)0x01000000) /* Bit 0 */
-#define GPIO_CFGHR_MODE14_1                     ((uint32_t)0x02000000) /* Bit 1 */
-
-#define GPIO_CFGHR_MODE15                       ((uint32_t)0x30000000) /* MODE15[1:0] bits (Port x mode bits, pin 15) */
-#define GPIO_CFGHR_MODE15_0                     ((uint32_t)0x10000000) /* Bit 0 */
-#define GPIO_CFGHR_MODE15_1                     ((uint32_t)0x20000000) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF                          ((uint32_t)0xCCCCCCCC) /* Port x configuration bits */
-
-#define GPIO_CFGHR_CNF8                         ((uint32_t)0x0000000C) /* CNF8[1:0] bits (Port x configuration bits, pin 8) */
-#define GPIO_CFGHR_CNF8_0                       ((uint32_t)0x00000004) /* Bit 0 */
-#define GPIO_CFGHR_CNF8_1                       ((uint32_t)0x00000008) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF9                         ((uint32_t)0x000000C0) /* CNF9[1:0] bits (Port x configuration bits, pin 9) */
-#define GPIO_CFGHR_CNF9_0                       ((uint32_t)0x00000040) /* Bit 0 */
-#define GPIO_CFGHR_CNF9_1                       ((uint32_t)0x00000080) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF10                        ((uint32_t)0x00000C00) /* CNF10[1:0] bits (Port x configuration bits, pin 10) */
-#define GPIO_CFGHR_CNF10_0                      ((uint32_t)0x00000400) /* Bit 0 */
-#define GPIO_CFGHR_CNF10_1                      ((uint32_t)0x00000800) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF11                        ((uint32_t)0x0000C000) /* CNF11[1:0] bits (Port x configuration bits, pin 11) */
-#define GPIO_CFGHR_CNF11_0                      ((uint32_t)0x00004000) /* Bit 0 */
-#define GPIO_CFGHR_CNF11_1                      ((uint32_t)0x00008000) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF12                        ((uint32_t)0x000C0000) /* CNF12[1:0] bits (Port x configuration bits, pin 12) */
-#define GPIO_CFGHR_CNF12_0                      ((uint32_t)0x00040000) /* Bit 0 */
-#define GPIO_CFGHR_CNF12_1                      ((uint32_t)0x00080000) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF13                        ((uint32_t)0x00C00000) /* CNF13[1:0] bits (Port x configuration bits, pin 13) */
-#define GPIO_CFGHR_CNF13_0                      ((uint32_t)0x00400000) /* Bit 0 */
-#define GPIO_CFGHR_CNF13_1                      ((uint32_t)0x00800000) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF14                        ((uint32_t)0x0C000000) /* CNF14[1:0] bits (Port x configuration bits, pin 14) */
-#define GPIO_CFGHR_CNF14_0                      ((uint32_t)0x04000000) /* Bit 0 */
-#define GPIO_CFGHR_CNF14_1                      ((uint32_t)0x08000000) /* Bit 1 */
-
-#define GPIO_CFGHR_CNF15                        ((uint32_t)0xC0000000) /* CNF15[1:0] bits (Port x configuration bits, pin 15) */
-#define GPIO_CFGHR_CNF15_0                      ((uint32_t)0x40000000) /* Bit 0 */
-#define GPIO_CFGHR_CNF15_1                      ((uint32_t)0x80000000) /* Bit 1 */
-
 /*******************  Bit definition for GPIO_INDR register  *******************/
-#define GPIO_INDR_IDR0                          ((uint16_t)0x0001) /* Port input data, bit 0 */
-#define GPIO_INDR_IDR1                          ((uint16_t)0x0002) /* Port input data, bit 1 */
-#define GPIO_INDR_IDR2                          ((uint16_t)0x0004) /* Port input data, bit 2 */
-#define GPIO_INDR_IDR3                          ((uint16_t)0x0008) /* Port input data, bit 3 */
-#define GPIO_INDR_IDR4                          ((uint16_t)0x0010) /* Port input data, bit 4 */
-#define GPIO_INDR_IDR5                          ((uint16_t)0x0020) /* Port input data, bit 5 */
-#define GPIO_INDR_IDR6                          ((uint16_t)0x0040) /* Port input data, bit 6 */
-#define GPIO_INDR_IDR7                          ((uint16_t)0x0080) /* Port input data, bit 7 */
-#define GPIO_INDR_IDR8                          ((uint16_t)0x0100) /* Port input data, bit 8 */
-#define GPIO_INDR_IDR9                          ((uint16_t)0x0200) /* Port input data, bit 9 */
-#define GPIO_INDR_IDR10                         ((uint16_t)0x0400) /* Port input data, bit 10 */
-#define GPIO_INDR_IDR11                         ((uint16_t)0x0800) /* Port input data, bit 11 */
-#define GPIO_INDR_IDR12                         ((uint16_t)0x1000) /* Port input data, bit 12 */
-#define GPIO_INDR_IDR13                         ((uint16_t)0x2000) /* Port input data, bit 13 */
-#define GPIO_INDR_IDR14                         ((uint16_t)0x4000) /* Port input data, bit 14 */
-#define GPIO_INDR_IDR15                         ((uint16_t)0x8000) /* Port input data, bit 15 */
+#define GPIO_INDR_IDR0                          ((uint32_t)0x00000001) /* Port input data, bit 0 */
+#define GPIO_INDR_IDR1                          ((uint32_t)0x00000002) /* Port input data, bit 1 */
+#define GPIO_INDR_IDR2                          ((uint32_t)0x00000004) /* Port input data, bit 2 */
+#define GPIO_INDR_IDR3                          ((uint32_t)0x00000008) /* Port input data, bit 3 */
+#define GPIO_INDR_IDR4                          ((uint32_t)0x00000010) /* Port input data, bit 4 */
+#define GPIO_INDR_IDR5                          ((uint32_t)0x00000020) /* Port input data, bit 5 */
+#define GPIO_INDR_IDR6                          ((uint32_t)0x00000040) /* Port input data, bit 6 */
+#define GPIO_INDR_IDR7                          ((uint32_t)0x00000080) /* Port input data, bit 7 */
 
 /*******************  Bit definition for GPIO_OUTDR register  *******************/
-#define GPIO_OUTDR_ODR0                         ((uint16_t)0x0001) /* Port output data, bit 0 */
-#define GPIO_OUTDR_ODR1                         ((uint16_t)0x0002) /* Port output data, bit 1 */
-#define GPIO_OUTDR_ODR2                         ((uint16_t)0x0004) /* Port output data, bit 2 */
-#define GPIO_OUTDR_ODR3                         ((uint16_t)0x0008) /* Port output data, bit 3 */
-#define GPIO_OUTDR_ODR4                         ((uint16_t)0x0010) /* Port output data, bit 4 */
-#define GPIO_OUTDR_ODR5                         ((uint16_t)0x0020) /* Port output data, bit 5 */
-#define GPIO_OUTDR_ODR6                         ((uint16_t)0x0040) /* Port output data, bit 6 */
-#define GPIO_OUTDR_ODR7                         ((uint16_t)0x0080) /* Port output data, bit 7 */
-#define GPIO_OUTDR_ODR8                         ((uint16_t)0x0100) /* Port output data, bit 8 */
-#define GPIO_OUTDR_ODR9                         ((uint16_t)0x0200) /* Port output data, bit 9 */
-#define GPIO_OUTDR_ODR10                        ((uint16_t)0x0400) /* Port output data, bit 10 */
-#define GPIO_OUTDR_ODR11                        ((uint16_t)0x0800) /* Port output data, bit 11 */
-#define GPIO_OUTDR_ODR12                        ((uint16_t)0x1000) /* Port output data, bit 12 */
-#define GPIO_OUTDR_ODR13                        ((uint16_t)0x2000) /* Port output data, bit 13 */
-#define GPIO_OUTDR_ODR14                        ((uint16_t)0x4000) /* Port output data, bit 14 */
-#define GPIO_OUTDR_ODR15                        ((uint16_t)0x8000) /* Port output data, bit 15 */
+#define GPIO_OUTDR_ODR0                         ((uint32_t)0x00000001) /* Port output data, bit 0 */
+#define GPIO_OUTDR_ODR1                         ((uint32_t)0x00000002) /* Port output data, bit 1 */
+#define GPIO_OUTDR_ODR2                         ((uint32_t)0x00000004) /* Port output data, bit 2 */
+#define GPIO_OUTDR_ODR3                         ((uint32_t)0x00000008) /* Port output data, bit 3 */
+#define GPIO_OUTDR_ODR4                         ((uint32_t)0x00000010) /* Port output data, bit 4 */
+#define GPIO_OUTDR_ODR5                         ((uint32_t)0x00000020) /* Port output data, bit 5 */
+#define GPIO_OUTDR_ODR6                         ((uint32_t)0x00000040) /* Port output data, bit 6 */
+#define GPIO_OUTDR_ODR7                         ((uint32_t)0x00000080) /* Port output data, bit 7 */
 
 /******************  Bit definition for GPIO_BSHR register  *******************/
 #define GPIO_BSHR_BS0                           ((uint32_t)0x00000001) /* Port x Set bit 0 */
@@ -1654,14 +1517,6 @@ typedef struct
 #define GPIO_BSHR_BS5                           ((uint32_t)0x00000020) /* Port x Set bit 5 */
 #define GPIO_BSHR_BS6                           ((uint32_t)0x00000040) /* Port x Set bit 6 */
 #define GPIO_BSHR_BS7                           ((uint32_t)0x00000080) /* Port x Set bit 7 */
-#define GPIO_BSHR_BS8                           ((uint32_t)0x00000100) /* Port x Set bit 8 */
-#define GPIO_BSHR_BS9                           ((uint32_t)0x00000200) /* Port x Set bit 9 */
-#define GPIO_BSHR_BS10                          ((uint32_t)0x00000400) /* Port x Set bit 10 */
-#define GPIO_BSHR_BS11                          ((uint32_t)0x00000800) /* Port x Set bit 11 */
-#define GPIO_BSHR_BS12                          ((uint32_t)0x00001000) /* Port x Set bit 12 */
-#define GPIO_BSHR_BS13                          ((uint32_t)0x00002000) /* Port x Set bit 13 */
-#define GPIO_BSHR_BS14                          ((uint32_t)0x00004000) /* Port x Set bit 14 */
-#define GPIO_BSHR_BS15                          ((uint32_t)0x00008000) /* Port x Set bit 15 */
 
 #define GPIO_BSHR_BR0                           ((uint32_t)0x00010000) /* Port x Reset bit 0 */
 #define GPIO_BSHR_BR1                           ((uint32_t)0x00020000) /* Port x Reset bit 1 */
@@ -1671,32 +1526,16 @@ typedef struct
 #define GPIO_BSHR_BR5                           ((uint32_t)0x00200000) /* Port x Reset bit 5 */
 #define GPIO_BSHR_BR6                           ((uint32_t)0x00400000) /* Port x Reset bit 6 */
 #define GPIO_BSHR_BR7                           ((uint32_t)0x00800000) /* Port x Reset bit 7 */
-#define GPIO_BSHR_BR8                           ((uint32_t)0x01000000) /* Port x Reset bit 8 */
-#define GPIO_BSHR_BR9                           ((uint32_t)0x02000000) /* Port x Reset bit 9 */
-#define GPIO_BSHR_BR10                          ((uint32_t)0x04000000) /* Port x Reset bit 10 */
-#define GPIO_BSHR_BR11                          ((uint32_t)0x08000000) /* Port x Reset bit 11 */
-#define GPIO_BSHR_BR12                          ((uint32_t)0x10000000) /* Port x Reset bit 12 */
-#define GPIO_BSHR_BR13                          ((uint32_t)0x20000000) /* Port x Reset bit 13 */
-#define GPIO_BSHR_BR14                          ((uint32_t)0x40000000) /* Port x Reset bit 14 */
-#define GPIO_BSHR_BR15                          ((uint32_t)0x80000000) /* Port x Reset bit 15 */
 
 /*******************  Bit definition for GPIO_BCR register  *******************/
-#define GPIO_BCR_BR0                            ((uint16_t)0x0001) /* Port x Reset bit 0 */
-#define GPIO_BCR_BR1                            ((uint16_t)0x0002) /* Port x Reset bit 1 */
-#define GPIO_BCR_BR2                            ((uint16_t)0x0004) /* Port x Reset bit 2 */
-#define GPIO_BCR_BR3                            ((uint16_t)0x0008) /* Port x Reset bit 3 */
-#define GPIO_BCR_BR4                            ((uint16_t)0x0010) /* Port x Reset bit 4 */
-#define GPIO_BCR_BR5                            ((uint16_t)0x0020) /* Port x Reset bit 5 */
-#define GPIO_BCR_BR6                            ((uint16_t)0x0040) /* Port x Reset bit 6 */
-#define GPIO_BCR_BR7                            ((uint16_t)0x0080) /* Port x Reset bit 7 */
-#define GPIO_BCR_BR8                            ((uint16_t)0x0100) /* Port x Reset bit 8 */
-#define GPIO_BCR_BR9                            ((uint16_t)0x0200) /* Port x Reset bit 9 */
-#define GPIO_BCR_BR10                           ((uint16_t)0x0400) /* Port x Reset bit 10 */
-#define GPIO_BCR_BR11                           ((uint16_t)0x0800) /* Port x Reset bit 11 */
-#define GPIO_BCR_BR12                           ((uint16_t)0x1000) /* Port x Reset bit 12 */
-#define GPIO_BCR_BR13                           ((uint16_t)0x2000) /* Port x Reset bit 13 */
-#define GPIO_BCR_BR14                           ((uint16_t)0x4000) /* Port x Reset bit 14 */
-#define GPIO_BCR_BR15                           ((uint16_t)0x8000) /* Port x Reset bit 15 */
+#define GPIO_BCR_BR0                            ((uint32_t)0x00000001) /* Port x Reset bit 0 */
+#define GPIO_BCR_BR1                            ((uint32_t)0x00000002) /* Port x Reset bit 1 */
+#define GPIO_BCR_BR2                            ((uint32_t)0x00000004) /* Port x Reset bit 2 */
+#define GPIO_BCR_BR3                            ((uint32_t)0x00000008) /* Port x Reset bit 3 */
+#define GPIO_BCR_BR4                            ((uint32_t)0x00000010) /* Port x Reset bit 4 */
+#define GPIO_BCR_BR5                            ((uint32_t)0x00000020) /* Port x Reset bit 5 */
+#define GPIO_BCR_BR6                            ((uint32_t)0x00000040) /* Port x Reset bit 6 */
+#define GPIO_BCR_BR7                            ((uint32_t)0x00000080) /* Port x Reset bit 7 */
 
 /******************  Bit definition for GPIO_LCKR register  *******************/
 #define GPIO_LCK0                               ((uint32_t)0x00000001) /* Port x Lock bit 0 */
@@ -1707,120 +1546,79 @@ typedef struct
 #define GPIO_LCK5                               ((uint32_t)0x00000020) /* Port x Lock bit 5 */
 #define GPIO_LCK6                               ((uint32_t)0x00000040) /* Port x Lock bit 6 */
 #define GPIO_LCK7                               ((uint32_t)0x00000080) /* Port x Lock bit 7 */
-#define GPIO_LCK8                               ((uint32_t)0x00000100) /* Port x Lock bit 8 */
-#define GPIO_LCK9                               ((uint32_t)0x00000200) /* Port x Lock bit 9 */
-#define GPIO_LCK10                              ((uint32_t)0x00000400) /* Port x Lock bit 10 */
-#define GPIO_LCK11                              ((uint32_t)0x00000800) /* Port x Lock bit 11 */
-#define GPIO_LCK12                              ((uint32_t)0x00001000) /* Port x Lock bit 12 */
-#define GPIO_LCK13                              ((uint32_t)0x00002000) /* Port x Lock bit 13 */
-#define GPIO_LCK14                              ((uint32_t)0x00004000) /* Port x Lock bit 14 */
-#define GPIO_LCK15                              ((uint32_t)0x00008000) /* Port x Lock bit 15 */
 #define GPIO_LCKK                               ((uint32_t)0x00010000) /* Lock key */
-
 
 /******************  Bit definition for AFIO_PCFR1register  *******************/
 #define AFIO_PCFR1_SPI1_REMAP                   ((uint32_t)0x00000001) /* SPI1 remapping */
 #define AFIO_PCFR1_I2C1_REMAP                   ((uint32_t)0x00000002) /* I2C1 remapping */
 #define AFIO_PCFR1_USART1_REMAP                 ((uint32_t)0x00000004) /* USART1 remapping */
 #define AFIO_PCFR1_USART1_REMAP_1               ((uint32_t)0x00200000) /* USART1 remapping higher bit */
-#define AFIO_PCFR1_USART2_REMAP                 ((uint32_t)0x00000008) /* USART2 remapping */
-
-#define AFIO_PCFR1_USART3_REMAP                 ((uint32_t)0x00000030) /* USART3_REMAP[1:0] bits (USART3 remapping) */
-#define AFIO_PCFR1_USART3_REMAP_0               ((uint32_t)0x00000010) /* Bit 0 */
-#define AFIO_PCFR1_USART3_REMAP_1               ((uint32_t)0x00000020) /* Bit 1 */
-
-#define AFIO_PCFR1_USART3_REMAP_NOREMAP         ((uint32_t)0x00000000) /* No remap (TX/PB10, RX/PB11, CK/PB12, CTS/PB13, RTS/PB14) */
-#define AFIO_PCFR1_USART3_REMAP_PARTIALREMAP    ((uint32_t)0x00000010) /* Partial remap (TX/PC10, RX/PC11, CK/PC12, CTS/PB13, RTS/PB14) */
-#define AFIO_PCFR1_USART3_REMAP_FULLREMAP       ((uint32_t)0x00000030) /* Full remap (TX/PD8, RX/PD9, CK/PD10, CTS/PD11, RTS/PD12) */
 
 #define AFIO_PCFR1_TIM1_REMAP                   ((uint32_t)0x000000C0) /* TIM1_REMAP[1:0] bits (TIM1 remapping) */
 #define AFIO_PCFR1_TIM1_REMAP_0                 ((uint32_t)0x00000040) /* Bit 0 */
 #define AFIO_PCFR1_TIM1_REMAP_1                 ((uint32_t)0x00000080) /* Bit 1 */
-
-#define AFIO_PCFR1_TIM1_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PB12, CH1N/PB13, CH2N/PB14, CH3N/PB15) */
-#define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP1     ((uint32_t)0x00000040) /* Partial remap (ETR/PA12, CH1/PA8, CH2/PA9, CH3/PA10, CH4/PA11, BKIN/PA6, CH1N/PA7, CH2N/PB0, CH3N/PB1) */
-#define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP      AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP1  /* legacy compatibility */
+#define AFIO_PCFR1_TIM1_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap      (ETR/PC5, CH1/PD2, CH2/PA1, CH3/PC3, CH4/PC4, BKIN/PC2, CH1N/PD0, CH2N/PA2, CH3N/PD1) */
+#define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP1     ((uint32_t)0x00000040) /* Partial remap (ETR/PC5, CH1/PC6, CH2/PC7, CH3/PC0, CH4/PD3, BKIN/PC1, CH1N/PC3, CH2N/PC4, CH3N/PD1) */
 #define AFIO_PCFR1_TIM1_REMAP_PARTIALREMAP2     ((uint32_t)0x00000080) /* Partial remap (ETR/PD4, CH1/PD2, CH2/PA1, CH3/PC3, CH4/PC4, BKIN/PC2, CH1N/PD0, CN2N/PA2, CH3N/PD1) */
-#define AFIO_PCFR1_TIM1_REMAP_FULLREMAP         ((uint32_t)0x000000C0) /* Full remap (ETR/PE7, CH1/PE9, CH2/PE11, CH3/PE13, CH4/PE14, BKIN/PE15, CH1N/PE8, CH2N/PE10, CH3N/PE12) */
+#define AFIO_PCFR1_TIM1_REMAP_FULLREMAP         ((uint32_t)0x000000C0) /* Full remap    (ETR/PC2, CH1/PC4, CH2/PC7, CH3/PC5, CH4/PD4, BKIN/PC1, CH1N/PC3, CH2N/PD2, CH3N/PC6) */
 
 #define AFIO_PCFR1_TIM2_REMAP                   ((uint32_t)0x00000300) /* TIM2_REMAP[1:0] bits (TIM2 remapping) */
 #define AFIO_PCFR1_TIM2_REMAP_0                 ((uint32_t)0x00000100) /* Bit 0 */
 #define AFIO_PCFR1_TIM2_REMAP_1                 ((uint32_t)0x00000200) /* Bit 1 */
-
-#define AFIO_PCFR1_TIM2_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/ETR/PA0, CH2/PA1, CH3/PA2, CH4/PA3) */
-#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP1     ((uint32_t)0x00000100) /* Partial remap (CH1/ETR/PA15, CH2/PB3, CH3/PA2, CH4/PA3) */
-#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP2     ((uint32_t)0x00000200) /* Partial remap (CH1/ETR/PA0, CH2/PA1, CH3/PB10, CH4/PB11) */
-#define AFIO_PCFR1_TIM2_REMAP_FULLREMAP         ((uint32_t)0x00000300) /* Full remap (CH1/ETR/PA15, CH2/PB3, CH3/PB10, CH4/PB11) */
-
-#define AFIO_PCFR1_TIM3_REMAP                   ((uint32_t)0x00000C00) /* TIM3_REMAP[1:0] bits (TIM3 remapping) */
-#define AFIO_PCFR1_TIM3_REMAP_0                 ((uint32_t)0x00000400) /* Bit 0 */
-#define AFIO_PCFR1_TIM3_REMAP_1                 ((uint32_t)0x00000800) /* Bit 1 */
-
-#define AFIO_PCFR1_TIM3_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap (CH1/PA6, CH2/PA7, CH3/PB0, CH4/PB1) */
-#define AFIO_PCFR1_TIM3_REMAP_PARTIALREMAP      ((uint32_t)0x00000800) /* Partial remap (CH1/PB4, CH2/PB5, CH3/PB0, CH4/PB1) */
-#define AFIO_PCFR1_TIM3_REMAP_FULLREMAP         ((uint32_t)0x00000C00) /* Full remap (CH1/PC6, CH2/PC7, CH3/PC8, CH4/PC9) */
-
-#define AFIO_PCFR1_TIM4_REMAP                   ((uint32_t)0x00001000) /* TIM4_REMAP bit (TIM4 remapping) */
-
-#define AFIO_PCFR1_CAN_REMAP                    ((uint32_t)0x00006000) /* CAN_REMAP[1:0] bits (CAN Alternate function remapping) */
-#define AFIO_PCFR1_CAN_REMAP_0                  ((uint32_t)0x00002000) /* Bit 0 */
-#define AFIO_PCFR1_CAN_REMAP_1                  ((uint32_t)0x00004000) /* Bit 1 */
-
-#define AFIO_PCFR1_CAN_REMAP_REMAP1             ((uint32_t)0x00000000) /* CANRX mapped to PA11, CANTX mapped to PA12 */
-#define AFIO_PCFR1_CAN_REMAP_REMAP2             ((uint32_t)0x00004000) /* CANRX mapped to PB8, CANTX mapped to PB9 */
-#define AFIO_PCFR1_CAN_REMAP_REMAP3             ((uint32_t)0x00006000) /* CANRX mapped to PD0, CANTX mapped to PD1 */
+#define AFIO_PCFR1_TIM2_REMAP_NOREMAP           ((uint32_t)0x00000000) /* No remap      (CH1/ETR/PD4, CH2/PD3, CH3/PC0, CH4/PD4) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP1     ((uint32_t)0x00000100) /* Partial remap (CH1/ETR/PC5, CH2/PC2, CH3/PD4, CH4/PC1) */
+#define AFIO_PCFR1_TIM2_REMAP_PARTIALREMAP2     ((uint32_t)0x00000200) /* Partial remap (CH1/ETR/PC1, CH2/PD3, CH3/PC0, CH4/PD7) */
+#define AFIO_PCFR1_TIM2_REMAP_FULLREMAP         ((uint32_t)0x00000300) /* Full remap    (CH1/ETR/PC1, CH2/PC7, CH3/PD6, CH4/PD5) */
 
 #define AFIO_PCFR1_PA12_REMAP                   ((uint32_t)0x00008000) /* Port D0/Port D1 mapping on OSC_IN/OSC_OUT */
-#define AFIO_PCFR1_TIM5CH4_IREMAP               ((uint32_t)0x00010000) /* TIM5 Channel4 Internal Remap */
 #define AFIO_PCFR1_ADC1_ETRGINJ_REMAP           ((uint32_t)0x00020000) /* ADC 1 External Trigger Injected Conversion remapping */
 #define AFIO_PCFR1_ADC1_ETRGREG_REMAP           ((uint32_t)0x00040000) /* ADC 1 External Trigger Regular Conversion remapping */
-#define AFIO_PCFR1_ADC2_ETRGINJ_REMAP           ((uint32_t)0x00080000) /* ADC 2 External Trigger Injected Conversion remapping */
-#define AFIO_PCFR1_ADC2_ETRGREG_REMAP           ((uint32_t)0x00100000) /* ADC 2 External Trigger Regular Conversion remapping */
 
-#define AFIO_PCFR1_USART1_HIGH_BIT_REMAP        ((uint32_t)0x00200000)
 #define AFIO_PCFR1_I2C1_HIGH_BIT_REMAP          ((uint32_t)0x00400000)
 #define AFIO_PCFR1_TIM1_1_RM                    ((uint32_t)0x00800000)
 
-#define AFIO_PCFR1_SWJ_CFG                      ((uint32_t)0x07000000) /* SWJ_CFG[2:0] bits (Serial Wire JTAG configuration) */
-#define AFIO_PCFR1_SWJ_CFG_0                    ((uint32_t)0x01000000) /* Bit 0 */
-#define AFIO_PCFR1_SWJ_CFG_1                    ((uint32_t)0x02000000) /* Bit 1 */
-#define AFIO_PCFR1_SWJ_CFG_2                    ((uint32_t)0x04000000) /* Bit 2 */
-
-#define AFIO_PCFR1_SWJ_CFG_RESET                ((uint32_t)0x00000000) /* Full SWJ (JTAG-DP + SW-DP) : Reset State */
-#define AFIO_PCFR1_SWJ_CFG_NOJNTRST             ((uint32_t)0x01000000) /* Full SWJ (JTAG-DP + SW-DP) but without JNTRST */
-#define AFIO_PCFR1_SWJ_CFG_JTAGDISABLE          ((uint32_t)0x02000000) /* JTAG-DP Disabled and SW-DP Enabled */
-#define AFIO_PCFR1_SWJ_CFG_DISABLE              ((uint32_t)0x04000000) /* JTAG-DP Disabled and SW-DP Disabled */
+#define AFIO_PCFR1_SWCFG                      ((uint32_t)0x07000000) /* SWCFG[2:0] bits (Serial Wire IO Debug configuration) */
+#define AFIO_PCFR1_SWCFG_0                    ((uint32_t)0x01000000) /* Bit 0 */
+#define AFIO_PCFR1_SWCFG_1                    ((uint32_t)0x02000000) /* Bit 1 */
+#define AFIO_PCFR1_SWCFG_2                    ((uint32_t)0x04000000) /* Bit 2 */
+#define AFIO_PCFR1_SWCFG_ENABLE               ((uint32_t)0x00000000) /* SWD (SDI) enabled  */
+#define AFIO_PCFR1_SWCFG_DISABLE              ((uint32_t)0x04000000) /* SWD (SDI) disabled */
 
 
 /*****************  Bit definition for AFIO_EXTICR register  *****************/
-#define AFIO_EXTICR1_EXTI0                      ((uint16_t)0x0003) /* EXTI 0 configuration */
-#define AFIO_EXTICR1_EXTI1                      ((uint16_t)0x000C) /* EXTI 1 configuration */
-#define AFIO_EXTICR1_EXTI2                      ((uint16_t)0x0030) /* EXTI 2 configuration */
-#define AFIO_EXTICR1_EXTI3                      ((uint16_t)0x00C0) /* EXTI 3 configuration */
-#define AFIO_EXTICR1_EXTI4                      ((uint16_t)0x0300) /* EXTI 4 configuration */
-#define AFIO_EXTICR1_EXTI5                      ((uint16_t)0x0C00) /* EXTI 5 configuration */
-#define AFIO_EXTICR1_EXTI6                      ((uint16_t)0x3000) /* EXTI 6 configuration */
-#define AFIO_EXTICR1_EXTI7                      ((uint16_t)0xC000) /* EXTI 7 configuration */
+#define AFIO_EXTICR_EXTI0                       ((uint32_t)0x00000003) /* EXTI 0 configuration */
+#define AFIO_EXTICR_EXTI1                       ((uint32_t)0x0000000C) /* EXTI 1 configuration */
+#define AFIO_EXTICR_EXTI2                       ((uint32_t)0x00000030) /* EXTI 2 configuration */
+#define AFIO_EXTICR_EXTI3                       ((uint32_t)0x000000C0) /* EXTI 3 configuration */
+#define AFIO_EXTICR_EXTI4                       ((uint32_t)0x00000300) /* EXTI 4 configuration */
+#define AFIO_EXTICR_EXTI5                       ((uint32_t)0x00000C00) /* EXTI 5 configuration */
+#define AFIO_EXTICR_EXTI6                       ((uint32_t)0x00003000) /* EXTI 6 configuration */
+#define AFIO_EXTICR_EXTI7                       ((uint32_t)0x0000C000) /* EXTI 7 configuration */
 
-#define AFIO_EXTICR1_EXTI0_PC                   ((uint16_t)0x0002) /* PC[0] pin */
-#define AFIO_EXTICR1_EXTI0_PD                   ((uint16_t)0x0003) /* PD[0] pin */
-#define AFIO_EXTICR1_EXTI1_PA                   ((uint16_t)0x0000) /* PA[1] pin */
-#define AFIO_EXTICR1_EXTI1_PC                   ((uint16_t)0x0008) /* PC[1] pin */
-#define AFIO_EXTICR1_EXTI1_PD                   ((uint16_t)0x000C) /* PD[1] pin */
-#define AFIO_EXTICR1_EXTI2_PA                   ((uint16_t)0x0000) /* PA[2] pin */
-#define AFIO_EXTICR1_EXTI2_PC                   ((uint16_t)0x0020) /* PC[2] pin */
-#define AFIO_EXTICR1_EXTI2_PD                   ((uint16_t)0x0030) /* PD[2] pin */
-#define AFIO_EXTICR1_EXTI3_PC                   ((uint16_t)0x0080) /* PC[3] pin */
-#define AFIO_EXTICR1_EXTI3_PD                   ((uint16_t)0x00C0) /* PD[3] pin */
-#define AFIO_EXTICR1_EXTI4_PC                   ((uint16_t)0x0200) /* PC[4] pin */
-#define AFIO_EXTICR1_EXTI4_PD                   ((uint16_t)0x0300) /* PD[4] pin */
-#define AFIO_EXTICR1_EXTI5_PC                   ((uint16_t)0x0800) /* PC[5] pin */
-#define AFIO_EXTICR1_EXTI5_PD                   ((uint16_t)0x0C00) /* PD[5] pin */
-#define AFIO_EXTICR1_EXTI6_PC                   ((uint16_t)0x2000) /* PC[6] pin */
-#define AFIO_EXTICR1_EXTI6_PD                   ((uint16_t)0x3000) /* PD[6] pin */
-#define AFIO_EXTICR1_EXTI7_PC                   ((uint16_t)0x8000) /* PC[7] pin */
-#define AFIO_EXTICR1_EXTI7_PD                   ((uint16_t)0xC000) /* PD[7] pin */
-
+#define AFIO_EXTICR_EXTI0_PA                    ((uint32_t)0x00000000) /* PA[0] pin */
+#define AFIO_EXTICR_EXTI0_PC                    ((uint32_t)0x00000002) /* PC[0] pin */
+#define AFIO_EXTICR_EXTI0_PD                    ((uint32_t)0x00000003) /* PD[0] pin */
+#define AFIO_EXTICR_EXTI1_PA                    ((uint32_t)0x00000000) /* PA[1] pin */
+#define AFIO_EXTICR_EXTI1_PC                    ((uint32_t)0x00000008) /* PC[1] pin */
+#define AFIO_EXTICR_EXTI1_PD                    ((uint32_t)0x0000000C) /* PD[1] pin */
+#define AFIO_EXTICR_EXTI2_PA                    ((uint32_t)0x00000000) /* PA[2] pin */
+#define AFIO_EXTICR_EXTI2_PC                    ((uint32_t)0x00000020) /* PC[2] pin */
+#define AFIO_EXTICR_EXTI2_PD                    ((uint32_t)0x00000030) /* PD[2] pin */
+#define AFIO_EXTICR_EXTI3_PA                    ((uint32_t)0x00000000) /* PA[3] pin */
+#define AFIO_EXTICR_EXTI3_PC                    ((uint32_t)0x00000080) /* PC[3] pin */
+#define AFIO_EXTICR_EXTI3_PD                    ((uint32_t)0x000000C0) /* PD[3] pin */
+#define AFIO_EXTICR_EXTI4_PA                    ((uint32_t)0x00000000) /* PA[4] pin */
+#define AFIO_EXTICR_EXTI4_PC                    ((uint32_t)0x00000200) /* PC[4] pin */
+#define AFIO_EXTICR_EXTI4_PD                    ((uint32_t)0x00000300) /* PD[4] pin */
+#define AFIO_EXTICR_EXTI5_PA                    ((uint32_t)0x00000000) /* PA[5] pin */
+#define AFIO_EXTICR_EXTI5_PC                    ((uint32_t)0x00000800) /* PC[5] pin */
+#define AFIO_EXTICR_EXTI5_PD                    ((uint32_t)0x00000C00) /* PD[5] pin */
+#define AFIO_EXTICR_EXTI6_PA                    ((uint32_t)0x00000000) /* PA[6] pin */
+#define AFIO_EXTICR_EXTI6_PC                    ((uint32_t)0x00002000) /* PC[6] pin */
+#define AFIO_EXTICR_EXTI6_PD                    ((uint32_t)0x00003000) /* PD[6] pin */
+#define AFIO_EXTICR_EXTI7_PA                    ((uint32_t)0x00000000) /* PA[7] pin */
+#define AFIO_EXTICR_EXTI7_PC                    ((uint32_t)0x00008000) /* PC[7] pin */
+#define AFIO_EXTICR_EXTI7_PD                    ((uint32_t)0x0000C000) /* PD[7] pin */
 
 /******************************************************************************/
 /*                           Independent WATCHDOG                             */
@@ -1848,9 +1646,6 @@ typedef struct
 
 /*******************  Bit definition for I2C_CTLR1 register  ********************/
 #define I2C_CTLR1_PE                            ((uint16_t)0x0001) /* Peripheral Enable */
-#define I2C_CTLR1_SMBUS                         ((uint16_t)0x0002) /* SMBus Mode */
-#define I2C_CTLR1_SMBTYPE                       ((uint16_t)0x0008) /* SMBus Type */
-#define I2C_CTLR1_ENARP                         ((uint16_t)0x0010) /* ARP Enable */
 #define I2C_CTLR1_ENPEC                         ((uint16_t)0x0020) /* PEC Enable */
 #define I2C_CTLR1_ENGC                          ((uint16_t)0x0040) /* General Call Enable */
 #define I2C_CTLR1_NOSTRETCH                     ((uint16_t)0x0080) /* Clock Stretching Disable (Slave mode) */
@@ -1859,7 +1654,6 @@ typedef struct
 #define I2C_CTLR1_ACK                           ((uint16_t)0x0400) /* Acknowledge Enable */
 #define I2C_CTLR1_POS                           ((uint16_t)0x0800) /* Acknowledge/PEC Position (for data reception) */
 #define I2C_CTLR1_PEC                           ((uint16_t)0x1000) /* Packet Error Checking */
-#define I2C_CTLR1_ALERT                         ((uint16_t)0x2000) /* SMBus Alert */
 #define I2C_CTLR1_SWRST                         ((uint16_t)0x8000) /* Software Reset */
 
 /*******************  Bit definition for I2C_CTLR2 register  ********************/
@@ -1914,16 +1708,12 @@ typedef struct
 #define I2C_STAR1_AF                            ((uint16_t)0x0400) /* Acknowledge Failure */
 #define I2C_STAR1_OVR                           ((uint16_t)0x0800) /* Overrun/Underrun */
 #define I2C_STAR1_PECERR                        ((uint16_t)0x1000) /* PEC Error in reception */
-#define I2C_STAR1_TIMEOUT                       ((uint16_t)0x4000) /* Timeout or Tlow Error */
-#define I2C_STAR1_SMBALERT                      ((uint16_t)0x8000) /* SMBus Alert */
 
 /*******************  Bit definition for I2C_STAR2 register  ********************/
 #define I2C_STAR2_MSL                           ((uint16_t)0x0001) /* Master/Slave */
 #define I2C_STAR2_BUSY                          ((uint16_t)0x0002) /* Bus Busy */
 #define I2C_STAR2_TRA                           ((uint16_t)0x0004) /* Transmitter/Receiver */
 #define I2C_STAR2_GENCALL                       ((uint16_t)0x0010) /* General Call Address (Slave mode) */
-#define I2C_STAR2_SMBDEFAULT                    ((uint16_t)0x0020) /* SMBus Device Default Address (Slave mode) */
-#define I2C_STAR2_SMBHOST                       ((uint16_t)0x0040) /* SMBus Host Header (Slave mode) */
 #define I2C_STAR2_DUALF                         ((uint16_t)0x0080) /* Dual Flag (Slave mode) */
 #define I2C_STAR2_PEC                           ((uint16_t)0xFF00) /* Packet Error Checking Register */
 
@@ -1938,57 +1728,51 @@ typedef struct
 /******************************************************************************/
 
 /********************  Bit definition for PWR_CTLR register  ********************/
-#define PWR_CTLR_LPDS                           ((uint16_t)0x0001) /* Low-Power Deepsleep */
-#define PWR_CTLR_PDDS                           ((uint16_t)0x0002) /* Power Down Deepsleep */
-#define PWR_CTLR_CWUF                           ((uint16_t)0x0004) /* Clear Wakeup Flag */
-#define PWR_CTLR_CSBF                           ((uint16_t)0x0008) /* Clear Standby Flag */
-#define PWR_CTLR_PVDE                           ((uint16_t)0x0010) /* Power Voltage Detector Enable */
+#define PWR_CTLR_PDDS                           ((uint32_t)0x00000002) /* Power Down Deepsleep */
+#define PWR_CTLR_PVDE                           ((uint32_t)0x00000010) /* Power Voltage Detector Enable */
 
-#define PWR_CTLR_PLS                            ((uint16_t)0x00E0) /* PLS[2:0] bits (PVD Level Selection) */
-#define PWR_CTLR_PLS_0                          ((uint16_t)0x0020) /* Bit 0 */
-#define PWR_CTLR_PLS_1                          ((uint16_t)0x0040) /* Bit 1 */
-#define PWR_CTLR_PLS_2                          ((uint16_t)0x0080) /* Bit 2 */
+#define PWR_CTLR_PLS                            ((uint32_t)0x000000E0) /* PLS[2:0] bits (PVD Level Selection) */
+#define PWR_CTLR_PLS_0                          ((uint32_t)0x00000020) /* Bit 0 */
+#define PWR_CTLR_PLS_1                          ((uint32_t)0x00000040) /* Bit 1 */
+#define PWR_CTLR_PLS_2                          ((uint32_t)0x00000080) /* Bit 2 */
 
-#define PWR_PVDLevel_0                          ((uint16_t)0x0000)
-#define PWR_PVDLevel_1                          ((uint16_t)0x0020)
-#define PWR_PVDLevel_2                          ((uint16_t)0x0040)
-#define PWR_PVDLevel_3                          ((uint16_t)0x0060)
-#define PWR_PVDLevel_4                          ((uint16_t)0x0080)
-#define PWR_PVDLevel_5                          ((uint16_t)0x00A0)
-#define PWR_PVDLevel_6                          ((uint16_t)0x00C0)
-#define PWR_PVDLevel_7                          ((uint16_t)0x00E0)
-
-#define PWR_CTLR_DBP                            ((uint16_t)0x0100) /* Disable Backup Domain write protection */
+#define PWR_PVDLevel_0                          ((uint32_t)0x00000000)
+#define PWR_PVDLevel_1                          ((uint32_t)0x00000020)
+#define PWR_PVDLevel_2                          ((uint32_t)0x00000040)
+#define PWR_PVDLevel_3                          ((uint32_t)0x00000060)
+#define PWR_PVDLevel_4                          ((uint32_t)0x00000080)
+#define PWR_PVDLevel_5                          ((uint32_t)0x000000A0)
+#define PWR_PVDLevel_6                          ((uint32_t)0x000000C0)
+#define PWR_PVDLevel_7                          ((uint32_t)0x000000E0)
 
 /*******************  Bit definition for PWR_CSR register  ********************/
-#define PWR_CSR_WUF                             ((uint16_t)0x0001) /* Wakeup Flag */
-#define PWR_CSR_SBF                             ((uint16_t)0x0002) /* Standby Flag */
-#define PWR_CSR_PVDO                            ((uint16_t)0x0004) /* PVD Output */
-#define PWR_CSR_EWUP                            ((uint16_t)0x0100) /* Enable WKUP pin */
+#define PWR_CSR_PVDO                            ((uint32_t)0x00000004) /* PVD Output */
 
 /*******************  Bit definition for PWR_AWUCSR register  ********************/
-#define PWR_AWUCSR_AWUEN                        ((uint16_t)0x0002) 
+#define PWR_AWUCSR_AWUEN                        ((uint32_t)0x00000002) 
 
 /*******************  Bit definition for PWR_AWUWR register  ********************/
-#define PWR_AWUWR                               ((uint16_t)0x003F) 
+#define PWR_AWUWR                               ((uint32_t)0x0000003F) 
 
 /*******************  Bit definition for PWR_AWUWR register  ********************/
-#define PWR_AWUPSC                              ((uint16_t)0x000F) 
-#define PWR_AWUPSC_0                            ((uint16_t)0x0000)
-#define PWR_AWUPSC_2                            ((uint16_t)0x0002)
-#define PWR_AWUPSC_4                            ((uint16_t)0x0003)
-#define PWR_AWUPSC_8                            ((uint16_t)0x0004)
-#define PWR_AWUPSC_16                           ((uint16_t)0x0005)
-#define PWR_AWUPSC_32                           ((uint16_t)0x0006)
-#define PWR_AWUPSC_64                           ((uint16_t)0x0007)
-#define PWR_AWUPSC_128                          ((uint16_t)0x0008)
-#define PWR_AWUPSC_256                          ((uint16_t)0x0009)
-#define PWR_AWUPSC_512                          ((uint16_t)0x000A)
-#define PWR_AWUPSC_1024                         ((uint16_t)0x000B)
-#define PWR_AWUPSC_2048                         ((uint16_t)0x000C)
-#define PWR_AWUPSC_4096                         ((uint16_t)0x000D)
-#define PWR_AWUPSC_10240                        ((uint16_t)0x000E)
-#define PWR_AWUPSC_61440                        ((uint16_t)0x000F)
+#define PWR_AWUPSC                              ((uint32_t)0x0000000F) 
+#define PWR_AWUPSC_0                            ((uint32_t)0x00000000)
+#define PWR_AWUPSC_OFF0                         ((uint32_t)0x00000000)
+#define PWR_AWUPSC_OFF1                         ((uint32_t)0x00000001)
+#define PWR_AWUPSC_2                            ((uint32_t)0x00000002)
+#define PWR_AWUPSC_4                            ((uint32_t)0x00000003)
+#define PWR_AWUPSC_8                            ((uint32_t)0x00000004)
+#define PWR_AWUPSC_16                           ((uint32_t)0x00000005)
+#define PWR_AWUPSC_32                           ((uint32_t)0x00000006)
+#define PWR_AWUPSC_64                           ((uint32_t)0x00000007)
+#define PWR_AWUPSC_128                          ((uint32_t)0x00000008)
+#define PWR_AWUPSC_256                          ((uint32_t)0x00000009)
+#define PWR_AWUPSC_512                          ((uint32_t)0x0000000A)
+#define PWR_AWUPSC_1024                         ((uint32_t)0x0000000B)
+#define PWR_AWUPSC_2048                         ((uint32_t)0x0000000C)
+#define PWR_AWUPSC_4096                         ((uint32_t)0x0000000D)
+#define PWR_AWUPSC_10240                        ((uint32_t)0x0000000E)
+#define PWR_AWUPSC_61440                        ((uint32_t)0x0000000F)
 
 /******************************************************************************/
 /*                         Reset and Clock Control                            */
@@ -2051,45 +1835,42 @@ typedef struct
 #define RCC_ADCPRE_3                            ((uint32_t)0x00004000)
 #define RCC_ADCPRE_4                            ((uint32_t)0x00008000)
 
-#define RCC_ADCPRE_DIV2                         ((uint32_t)0x00000000) /* PCLK2 divided by 2 */
-#define RCC_ADCPRE_DIV4                         ((uint32_t)0x00004000) /* PCLK2 divided by 4 */
-#define RCC_ADCPRE_DIV6                         ((uint32_t)0x00008000) /* PCLK2 divided by 6 */
-#define RCC_ADCPRE_DIV8                         ((uint32_t)0x0000C000) /* PCLK2 divided by 8 */
+#define RCC_ADCPRE_DIV2                         ((uint32_t)0x00000000) /* HBCLK divided by 2 */
+/* includes                                                0x00000800,
+                                                           0x00001000,
+                                                           0x00001800 */
+#define RCC_ADCPRE_DIV4_1                       ((uint32_t)0x00002000) /* HBCLK divided by 4 */
+#define RCC_ADCPRE_DIV8_2                       ((uint32_t)0x00002800) /* HBCLK divided by 8 */
+#define RCC_ADCPRE_DIV16_2                      ((uint32_t)0x00003000) /* HBCLK divided by 16 */
+#define RCC_ADCPRE_DIV32_2                      ((uint32_t)0x00003800) /* HBCLK divided by 32 */
+#define RCC_ADCPRE_DIV4                         ((uint32_t)0x00004000) /* HBCLK divided by 4 */
+/* includes                                                0x00004800,
+                                                           0x00005000,
+                                                           0x00005800 */
+#define RCC_ADCPRE_DIV8_1                       ((uint32_t)0x00006000) /* HBCLK divided by 8 */
+#define RCC_ADCPRE_DIV16_1                      ((uint32_t)0x00006800) /* HBCLK divided by 16 */
+#define RCC_ADCPRE_DIV32_1                      ((uint32_t)0x00007000) /* HBCLK divided by 32 */
+#define RCC_ADCPRE_DIV64_1                      ((uint32_t)0x00007800) /* HBCLK divided by 64 */
+#define RCC_ADCPRE_DIV6                         ((uint32_t)0x00008000) /* HBCLK divided by 6 */
+/* includes                                                0x00008800,
+                                                           0x00009000,
+                                                           0x00009800 */
+#define RCC_ADCPRE_DIV12                        ((uint32_t)0x0000A000) /* HBCLK divided by 12 */
+#define RCC_ADCPRE_DIV24                        ((uint32_t)0x0000A800) /* HBCLK divided by 24 */
+#define RCC_ADCPRE_DIV48                        ((uint32_t)0x0000B000) /* HBCLK divided by 48 */
+#define RCC_ADCPRE_DIV96                        ((uint32_t)0x0000B800) /* HBCLK divided by 96 */
+#define RCC_ADCPRE_DIV8                         ((uint32_t)0x0000C000) /* HBCLK divided by 8 */
+/* includes                                                0x0000C800,
+                                                           0x0000D000,
+                                                           0x0000D800 */
+#define RCC_ADCPRE_DIV16                        ((uint32_t)0x0000E000) /* HBCLK divided by 16 */
+#define RCC_ADCPRE_DIV32                        ((uint32_t)0x0000E800) /* HBCLK divided by 32 */
+#define RCC_ADCPRE_DIV64                        ((uint32_t)0x0000F000) /* HBCLK divided by 64 */
+#define RCC_ADCPRE_DIV128                       ((uint32_t)0x0000F800) /* HBCLK divided by 128 */
 
 #define RCC_PLLSRC                              ((uint32_t)0x00010000) /* PLL entry clock source */
-
-#define RCC_PLLXTPRE                            ((uint32_t)0x00020000) /* HSE divider for PLL entry */
-
-#define RCC_PLLMULL                             ((uint32_t)0x003C0000) /* PLLMUL[3:0] bits (PLL multiplication factor) */
-#define RCC_PLLMULL_0                           ((uint32_t)0x00040000) /* Bit 0 */
-#define RCC_PLLMULL_1                           ((uint32_t)0x00080000) /* Bit 1 */
-#define RCC_PLLMULL_2                           ((uint32_t)0x00100000) /* Bit 2 */
-#define RCC_PLLMULL_3                           ((uint32_t)0x00200000) /* Bit 3 */
-
 #define RCC_PLLSRC_HSI_Mul2                     ((uint32_t)0x00000000) /* HSI clock*2 selected as PLL entry clock source */
 #define RCC_PLLSRC_HSE_Mul2                     ((uint32_t)0x00010000) /* HSE clock*2 selected as PLL entry clock source */
-
-#define RCC_PLLXTPRE_HSE                        ((uint32_t)0x00000000) /* HSE clock not divided for PLL entry */
-#define RCC_PLLXTPRE_HSE_Div2                   ((uint32_t)0x00020000) /* HSE clock divided by 2 for PLL entry */
-
-#define RCC_PLLMULL2                            ((uint32_t)0x00000000) /* PLL input clock*2 */
-#define RCC_PLLMULL3                            ((uint32_t)0x00040000) /* PLL input clock*3 */
-#define RCC_PLLMULL4                            ((uint32_t)0x00080000) /* PLL input clock*4 */
-#define RCC_PLLMULL5                            ((uint32_t)0x000C0000) /* PLL input clock*5 */
-#define RCC_PLLMULL6                            ((uint32_t)0x00100000) /* PLL input clock*6 */
-#define RCC_PLLMULL7                            ((uint32_t)0x00140000) /* PLL input clock*7 */
-#define RCC_PLLMULL8                            ((uint32_t)0x00180000) /* PLL input clock*8 */
-#define RCC_PLLMULL9                            ((uint32_t)0x001C0000) /* PLL input clock*9 */
-#define RCC_PLLMULL10                           ((uint32_t)0x00200000) /* PLL input clock10 */
-#define RCC_PLLMULL11                           ((uint32_t)0x00240000) /* PLL input clock*11 */
-#define RCC_PLLMULL12                           ((uint32_t)0x00280000) /* PLL input clock*12 */
-#define RCC_PLLMULL13                           ((uint32_t)0x002C0000) /* PLL input clock*13 */
-#define RCC_PLLMULL14                           ((uint32_t)0x00300000) /* PLL input clock*14 */
-#define RCC_PLLMULL15                           ((uint32_t)0x00340000) /* PLL input clock*15 */
-#define RCC_PLLMULL16                           ((uint32_t)0x00380000) /* PLL input clock*16 */
-
-
-#define RCC_USBPRE                              ((uint32_t)0x00400000) /* USB Device prescaler */
 
 #define RCC_CFGR0_MCO                           ((uint32_t)0x07000000) /* MCO[2:0] bits (Microcontroller Clock Output) */
 #define RCC_MCO_0                               ((uint32_t)0x01000000) /* Bit 0 */
@@ -2102,22 +1883,17 @@ typedef struct
 #define RCC_CFGR0_MCO_HSE                       ((uint32_t)0x06000000) /* HSE clock selected as MCO source  */
 #define RCC_CFGR0_MCO_PLL                       ((uint32_t)0x07000000) /* PLL clock divided by 2 selected as MCO source */
 
-/*******************  Bit definition for RCC_CFGR2 register  *******************/
-
 /*******************  Bit definition for RCC_INTR register  ********************/
 #define RCC_LSIRDYF                             ((uint32_t)0x00000001) /* LSI Ready Interrupt flag */
-#define RCC_LSERDYF                             ((uint32_t)0x00000002) /* LSE Ready Interrupt flag */
 #define RCC_HSIRDYF                             ((uint32_t)0x00000004) /* HSI Ready Interrupt flag */
 #define RCC_HSERDYF                             ((uint32_t)0x00000008) /* HSE Ready Interrupt flag */
 #define RCC_PLLRDYF                             ((uint32_t)0x00000010) /* PLL Ready Interrupt flag */
 #define RCC_CSSF                                ((uint32_t)0x00000080) /* Clock Security System Interrupt flag */
 #define RCC_LSIRDYIE                            ((uint32_t)0x00000100) /* LSI Ready Interrupt Enable */
-#define RCC_LSERDYIE                            ((uint32_t)0x00000200) /* LSE Ready Interrupt Enable */
 #define RCC_HSIRDYIE                            ((uint32_t)0x00000400) /* HSI Ready Interrupt Enable */
 #define RCC_HSERDYIE                            ((uint32_t)0x00000800) /* HSE Ready Interrupt Enable */
 #define RCC_PLLRDYIE                            ((uint32_t)0x00001000) /* PLL Ready Interrupt Enable */
 #define RCC_LSIRDYC                             ((uint32_t)0x00010000) /* LSI Ready Interrupt Clear */
-#define RCC_LSERDYC                             ((uint32_t)0x00020000) /* LSE Ready Interrupt Clear */
 #define RCC_HSIRDYC                             ((uint32_t)0x00040000) /* HSI Ready Interrupt Clear */
 #define RCC_HSERDYC                             ((uint32_t)0x00080000) /* HSE Ready Interrupt Clear */
 #define RCC_PLLRDYC                             ((uint32_t)0x00100000) /* PLL Ready Interrupt Clear */
@@ -3236,11 +3012,10 @@ static __I uint8_t ADCPrescTable[20] = {2, 4, 6, 8, 4, 8, 12, 16, 8, 16, 24, 32,
 
 
 
-/* ch32v00x_dbgmcu.h ---------------------------------------------------------*/
+/* ch32v003_dbgmcu.h ---------------------------------------------------------*/
 
 /* DBGMCU_CR Register */
 #define DBGMCU_SLEEP                 ((uint32_t)0x00000001)
-#define DBGMCU_STOP                  ((uint32_t)0x00000002)
 #define DBGMCU_STANDBY               ((uint32_t)0x00000004)
 #define DBGMCU_IWDG_STOP             ((uint32_t)0x00000100)
 #define DBGMCU_WWDG_STOP             ((uint32_t)0x00000200)

--- a/examples/exti_pin_change_isr/exti_pin_change_isr.c
+++ b/examples/exti_pin_change_isr/exti_pin_change_isr.c
@@ -82,7 +82,7 @@ int main()
 		 : : :  "t1" );
 
 	// Configure the IO as an interrupt.
-	AFIO->EXTICR = AFIO_EXTICR1_EXTI3_PD;
+	AFIO->EXTICR = AFIO_EXTICR_EXTI3_PD;
 	EXTI->INTENR = EXTI_INTENR_MR3; // Enable EXT3
 	EXTI->RTENR = EXTI_RTENR_TR3;  // Rising edge trigger
 


### PR DESCRIPTION
Removed INFO_BASE
Removed CRC_TypeDef
Removed DEBUGMCU_STOP
Fixed ESIG_TypeDef to match RM and 00x correct names 
Fixed USART_TypeDef to match RM and 00x convert from 16bit to 32bit and remove reserved padding. 
Fixed WWDG_TypeDef to match RM and 00x convert from 32bit to 16bit and add reserved padding. 
Removed EXTEND_TypeDef
Remove all GPIO_ defines for bits 8 and higher. We only have 8 bit registers 0-7 
Fixed GPIO_ defines to be 32 bit fields to match RM and 00x 
Fixed AFIO_PCFR1register to properly name remapping fields (comments mostly) and remove unused defines for things we don't have 
Removed dualmod defines from ADC_CTLR1
removed ADC_TSVREFE from ADC_CTLR2
Changed ADC_STATR to 32 bit from 8 bit
Changed ADC_IOFRx to 32 bit from 16 bit and corrected mask from 0x0fff to 0x02ff 
Changed ADC_WDHTR and ADC_WDLTR to 32 bit from 16 bit and corrected mask from 0x0fff to 0x02ff 
Changed ADC_IDATARx to 32 bit from 16 bit
Changed ADC_DLYR values to 32bit from 8 bit
Changed FLASH_STATR to 32 bit from a mixture of 8 and 16 bit 
Changed FLASH_CTLR to 32 bits from *nothing*
Removed FLASH_OBR defines not in RM
Changed FLASH_OBR to 32 bit from 16 bit
Changed FLASH_WPR defines to match RM
Removed GPIO_CFGHR defines as we don't have 16 bit gpio 
Cleanup AFIO_EXTI to add missing defines and make 32 bit. 
Remving I2C_CTLR1 defines for features not in RM
Removed I2C_STARx defines for SMbus.
Changed PWR_* to remove unsued defines and convert to 32 bit from 16 bit Enhance RCC_CFGR0 with *all* the ADC divider values 
Removed RCC_CFGR0 PLL divisors that are unused
Removed RCC_CFGR2 as there is none
Removed RCC_INTR defines that don't exist in the RM Changed TIM_SWEVGR to 16 bit from 8 bit
Changed TIM_CHxCVR to 32 bits from 16 bits and added LEVEL bits