### PR TITLE
Improve buffered terminal in minichlink

### DIFF
--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -405,9 +405,9 @@ keep_going:
 					fprintf( stdout, "\x1b[6n" );
 					fflush( stdout );
 					read( fileno(stdin), input_buf, 10 );
-					if (input_buf[0] == 27)
+					if (input_buf[0] != 27)
 					{
-						nice_terminal = isatty( fileno(stdout) );
+						nice_terminal = 0;
 					}
 					memset( input_buf, 0, sizeof(input_buf) );
 				}

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -382,6 +382,7 @@ keep_going:
 				}
 
 				CaptureKeyboardInput();
+				printf( "Terminal started\n\n" );
 
 #if TERMINAL_INPUT_BUFFER
 				char pline_buf[256]; // Buffer that contains current line that is being printed to
@@ -409,11 +410,15 @@ keep_going:
 					{
 						nice_terminal = 0;
 					}
+					else
+					{
+						printf( TERMINAL_SEND_LABEL );
+						fflush( stdout );
+					}
 					memset( input_buf, 0, sizeof(input_buf) );
 				}
 #endif
 #endif
-				printf( "Terminal started\n\n" );
 				uint32_t appendword = 0;
 				do
 				{
@@ -520,34 +525,24 @@ keep_going:
 							if ( nice_terminal )
 							{
 								int new_line = -1;
-								if( buffer[r - 1] == '\n' )
+								for( int i = r; i > 0; i-- )
 								{
-									new_line = 0;
-									strncpy( print_buf, TERMINAL_CLEAR_CUR, TERMINAL_BUFFER_SIZE - 1 ); // Go to the start of the line and erase it
-									strncat( pline_buf, (char *)buffer, r - new_line ); // Add newly received chars to line buffer
+									if( buffer[i-1] == '\n' )
+									{
+										new_line = r - i;
+										break;
+									}
+								}
+								if( new_line < 0 )
+								{
+									strncpy( print_buf, TERMINAL_CLEAR_PREV, TERMINAL_BUFFER_SIZE - 1 ); //  Go one line up and erase it
+									strncat( pline_buf, (char *)buffer, r); // Add newly received chars to line buffer
 								}
 								else
 								{
-									for( int i = r; i > 0; i-- )
-									{
-										if( buffer[i-1] == '\n' )
-										{
-											new_line = r - i;
-											break; 
-										}
-									}
-									if( new_line < 0 )
-									{
-										strncpy( print_buf, TERMINAL_CLEAR_PREV, TERMINAL_BUFFER_SIZE - 1 ); //  Go one line up and erase it
-										strncat( pline_buf, (char *)buffer, r); // Add newly received chars to line buffer
-									}
-									else
-									{
-										strncpy( print_buf, TERMINAL_CLEAR_CUR, TERMINAL_BUFFER_SIZE - 1 ); // Go to the start of the line and erase it
-										strncat( pline_buf, (char *)buffer, r - new_line ); // Add newly received chars to line buffer
-									}
+									strncpy( print_buf, TERMINAL_CLEAR_CUR, TERMINAL_BUFFER_SIZE - 1 ); // Go to the start of the line and erase it
+									strncat( pline_buf, (char *)buffer, r - new_line ); // Add newly received chars to line buffer
 								}
-								
 								strncat( print_buf, pline_buf, TERMINAL_BUFFER_SIZE - 1 - strlen(print_buf) ); // Add line to buffer
 								if( new_line >= 0 )
 								{

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -204,7 +204,7 @@ struct InternalState
 #endif
 
 #ifndef TERMINAL_INPUT_BUFFER
-#define TERMINAL_INPUT_BUFFER 1
+#define TERMINAL_INPUT_BUFFER 0
 #endif
 
 #define TERMINAL_BUFFER_SIZE 512

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -204,7 +204,7 @@ struct InternalState
 #endif
 
 #ifndef TERMINAL_INPUT_BUFFER
-#define TERMINAL_INPUT_BUFFER 0
+#define TERMINAL_INPUT_BUFFER 1
 #endif
 
 #define TERMINAL_BUFFER_SIZE 512

--- a/minichlink/pgm-b003fun.c
+++ b/minichlink/pgm-b003fun.c
@@ -582,6 +582,7 @@ int B003PollTerminal( void * dev, uint8_t * buffer, int maxlen, uint32_t leavefl
 		int num_printf_chars = (rr & 0xf)-4;
 		memcpy( buffer, eps->respbuffer+1, num_printf_chars );
 		*(buffer+num_printf_chars) = 0; //  For ease of mind make the buffer a C-string
+		if( num_printf_chars <= 0 ) return num_printf_chars-1;
 		return num_printf_chars;
 	}
 	else


### PR DESCRIPTION
Presented changes are still guarded by ifdefs and will have effect only when compiled with ``TERMINAL_INPUT_BUFFER 1``.
- Fixed broken prints when incoming string had new lines anywhere inside of it but not at the end
- Fixed ``Send:`` label not showing until first terminal activity
- Added detection of ANSI compatibility of used terminal
- Fixed acking in ``b003boot`` terminal (not connected to the rest of the changes, but it's just a one line, didn't want to create a separate PR for it)