### PR TITLE
Add sleep mode example for ch570-ch572

### DIFF
--- a/examples_ch5xx/ch570_sleepmode/Makefile
+++ b/examples_ch5xx/ch570_sleepmode/Makefile
@@ -1,0 +1,11 @@
+all : flash
+
+TARGET:=ch570_Sleep
+TARGET_MCU:=CH570
+TARGET_MCU_PACKAGE:=CH570D
+
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean
+

--- a/examples_ch5xx/ch570_sleepmode/README.md
+++ b/examples_ch5xx/ch570_sleepmode/README.md
@@ -1,0 +1,82 @@
+# CH570/CH572 Low Power Configuration
+
+## Power Consumption
+
+- In sleep mode with RAM retention, the MCU consumes approximately **0.9 µA**.  
+- In sleep mode with LSI, RTC and RAM retention, it consumes arnoud **1.2 µA**.
+- In shutdown mode with all functions disabled, it consumes about **0.6 µA**.
+
+CH570 and CH572 have identical low-power modes and configuration options.
+
+## Pin Configuration
+
+**Do not leave any pins floating.**  
+A floating pin with digital input enabled can draw extra current due to the internal Schmitt trigger.
+
+To avoid unnecessary power consumption, you can either:
+
+1. **Enable all internal pull-up resistors:**
+    ```c
+    R32_PA_PD_DRV = 0;
+    R32_PA_PU = 0xFFFFFFFF;
+    R32_PA_DIR = 0;
+    ```
+
+2. **Use external pull-up resistors.**
+
+3. **Disable all digital functions on the pins:**
+    ```c
+    R32_PA_PD_DRV = 0;
+    R32_PA_PU = 0;
+    R32_PA_DIR = 0;
+    R16_PIN_ALTERNATE = 0x0FFF;
+    ```
+
+After performing one of the above configurations, you can set up pin functions as needed for your application.
+
+---
+
+## LDO Configuration
+
+The CH570 and CH572 include an integrated 5V LDO. Configuration depends on the power supply source:
+
+### If powered via the V5 pin
+
+Set the `RB_PWR_LDO5V_EN` bit (in safe access):
+
+```c
+SYS_SAFE_ACCESS
+(
+	R16_POWER_PLAN |= RB_PWR_LDO5V_EN;
+);
+```
+
+---
+
+### If powered via the VCC pin
+
+Clear the `RB_PWR_LDO5V_EN` bit:
+
+```c
+SYS_SAFE_ACCESS
+(
+	R16_POWER_PLAN &= ~RB_PWR_LDO5V_EN;
+);
+```
+
+---
+
+If not configured correctly, the sleep current may increase by approximately 100 µA.  
+Although connecting a 1 MΩ resistor between VCC and V5 can help reduce this excess current, this workaround is not recommended.
+
+## System clock frequency
+
+If the clock frequency is below 60 Mhz, one can simply configure `R8_SLP_POWER_CTRL`, `R16_POWER_PLAN` and then call `__WFI()`.
+
+**For higher clock frequency like 100 Mhz, the flash will become unstable after waking up**
+
+Either lower the clock frequency before going into sleep mode, or let the code run in ram until flash is stable. Even when `RB_WAKE_DLY_MOD = 0x40`, another 40 µs or so is required before code can run in flash. Longer time is required for other parts like systick. So don't use `Delay_Us()` immedately, run some `__NOP()` in loops before you do anything else.
+
+## Unofficial test results
+
+- Datasheet asked for a 1.5k resistor between VCC and V5. Preliminary tests suggest that it is not necessary to do so. The MCU works fine without.

--- a/examples_ch5xx/ch570_sleepmode/ch570_Sleep.c
+++ b/examples_ch5xx/ch570_sleepmode/ch570_Sleep.c
@@ -1,0 +1,98 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+#define LED PA9
+
+// Datasheet refer to them differently.
+// SFR is still in early stage when this code is written.
+// So if anything breaks or won't compile
+// Try checking out ch5xxhw.h
+#define R16_RTC_CNT_LSI     R16_RTC_CNT_32K 
+#define R16_RTC_CNT_DIV1    R16_RTC_CNT_2S 
+#define RB_PWR_RAM12K       RB_PWR_RAM2K
+
+__attribute__((interrupt))
+void RTC_IRQHandler(void)
+{
+	// clear trigger flag
+	R8_RTC_FLAG_CTRL =  RB_RTC_TRIG_CLR;
+
+}
+
+//Enable pullup on all pins to reduce power consumption
+void allPinPullUp(void)
+{
+	R32_PA_DIR = 0; //Direction input
+	R32_PA_PD_DRV = 0; //Disable pull-down
+    R32_PA_PU = 0xFFFFFFFF; //Enable pull-up  
+    
+}
+
+//go to sleep mode with 12K RAM retention.
+void goToSleep(void)
+{
+	
+    PFIC->SCTLR |= (1 << 2); //deep sleep
+	SYS_SAFE_ACCESS
+	(
+ 	   R8_SLP_POWER_CTRL |= 0x40;
+  	   R16_POWER_PLAN = RB_PWR_PLAN_EN | RB_PWR_CORE | RB_PWR_RAM12K | (1<<12);
+    );
+	
+    __WFI();
+    __NOP();
+    __NOP();
+
+}
+
+//load all counter register with 0
+void rtcClear(void)
+{
+	SYS_SAFE_ACCESS
+	(
+		R32_RTC_TRIG = 0;
+		R32_RTC_CTRL |= RB_RTC_LOAD_HI;
+		R32_RTC_CTRL |= RB_RTC_LOAD_LO;
+    );
+
+}
+
+void rtcSleepWait(uint16_t seconds)
+{	
+	//get the rtc current time
+	uint32_t alarm = (uint32_t) R16_RTC_CNT_LSI | ( (uint32_t) R16_RTC_CNT_DIV1 << 16 );
+	alarm += seconds*32768; //Set trigger value assuming LSI is 32.768khz
+
+    SYS_SAFE_ACCESS
+    (
+		R32_RTC_TRIG = alarm;                 //set trigger value.
+		R8_RTC_MODE_CTRL |= RB_RTC_TRIG_EN;  //enable trigger
+   		R8_SLP_WAKE_CTRL |= RB_SLP_RTC_WAKE; // enable wakeup control
+    );
+
+    NVIC_EnableIRQ(RTC_IRQn);//enable RTC interrupt
+    goToSleep();
+
+}
+
+int main()
+{
+	SystemInit();
+	allPinPullUp();
+	R32_PA_DIR |= LED;//Enable output on LED pin.
+
+   	rtcClear();//init RTC.
+	
+    uint16_t i = 5; 
+    while(i--)
+    {
+    	rtcSleepWait(1); //Sleep for 1s
+    	R32_PA_SET |= LED; //turn off LED
+    	rtcSleepWait(1); //SLeep for 1s
+    	R32_PA_CLR |= LED;  //turn on LED
+    }
+
+    while(1);
+	
+}
+

--- a/examples_ch5xx/ch570_sleepmode/funconfig.h
+++ b/examples_ch5xx/ch570_sleepmode/funconfig.h
@@ -1,0 +1,13 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define FUNCONF_USE_HSI           0 // CH5xx does not have HSI
+#define FUNCONF_USE_HSE           1
+#define CLK_SOURCE_CH5XX          CLK_SOURCE_PLL_60MHz // default so not really needed
+#define FUNCONF_SYSTEM_CORE_CLOCK 60 * 1000 * 1000     // keep in line with CLK_SOURCE_CH5XX
+
+#define FUNCONF_DEBUG_HARDFAULT   0
+#define FUNCONF_USE_CLK_SEC       0
+#define FUNCONF_INIT_ANALOG       0 // ADC is not implemented yet
+
+#endif


### PR DESCRIPTION
This example shows how to put the MCU to sleep mode and wake it from an RTC interrupt.
The readme file contains some tips and test results regarding sleep mode.