### PR TITLE
minichlink: add linkW

### DIFF
--- a/minichlink/pgm-wch-linke.c
+++ b/minichlink/pgm-wch-linke.c
@@ -379,6 +379,9 @@ static int LESetupInterface( void * d )
 		case 4:
 			fprintf(stderr, "WCH Programmer is LinkB version %d.%d\n",rbuff[3], rbuff[4]);
 			break;
+		case 5:
+			fprintf(stderr, "WCH Programmer is LinkW version %d.%d\n",rbuff[3], rbuff[4]);
+			break;
 		case 18:
 			fprintf(stderr, "WCH Programmer is LinkE version %d.%d\n",rbuff[3], rbuff[4]);
 			break;


### PR DESCRIPTION
This is just to have the linkW reported as a linkW and not as Unknown. No functional changes at all, in my limited testing it seems to work as well as a linkE.