### PR TITLE
minichlink: builtin bootloader ISP programming

### DIFF
--- a/minichlink/Makefile
+++ b/minichlink/Makefile
@@ -1,7 +1,7 @@
 TOOLS:=minichlink minichlink.so
 
 CFLAGS:=-O0 -g3 -Wall -DCH32V003 -I. -DMINICHLINK
-C_S:=minichlink.c pgm-wch-linke.c pgm-esp32s2-ch32xx.c nhc-link042.c ardulink.c serial_dev.c pgm-b003fun.c minichgdb.c
+C_S:=minichlink.c pgm-wch-linke.c pgm-wch-isp.c pgm-esp32s2-ch32xx.c nhc-link042.c ardulink.c serial_dev.c pgm-b003fun.c minichgdb.c
 H_S:=cmdserver.h funconfig.h hidapi.h libusb.h microgdbstub.h minichlink.h serial_dev.h terminalhelp.h
 
 # General Note: To use with GDB, gdb-multiarch

--- a/minichlink/minichlink.c
+++ b/minichlink/minichlink.c
@@ -40,6 +40,8 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 	{
 		if( strcmp( specpgm, "linke" ) == 0 )
 			dev = TryInit_WCHLinkE();
+		else if( strcmp( specpgm, "isp" ) == 0 )
+			dev = TryInit_WCHISP();
 		else if( strcmp( specpgm, "esp32s2chfun" ) == 0 )
 			dev = TryInit_ESP32S2CHFUN();
 		else if( strcmp( specpgm, "nchlink" ) == 0 )
@@ -51,7 +53,11 @@ void * MiniCHLinkInitAsDLL( struct MiniChlinkFunctions ** MCFO, const init_hints
 	}
 	else
 	{
-		if( (dev = TryInit_WCHLinkE()) )
+		if( (dev = TryInit_WCHISP()) )
+		{
+			fprintf( stderr, "Found MCU in bootloader mode\n" );
+		}
+		else if( (dev = TryInit_WCHLinkE()) )
 		{
 			fprintf( stderr, "Found WCH Link\n" );
 		}

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -237,6 +237,7 @@ extern struct MiniChlinkFunctions MCF;
 
 // Returns 'dev' on success, else 0.
 void * TryInit_WCHLinkE(void);
+void * TryInit_WCHISP(void);
 void * TryInit_ESP32S2CHFUN(void);
 void * TryInit_NHCLink042(void);
 void * TryInit_B003Fun(uint32_t id);

--- a/minichlink/minichlink.h
+++ b/minichlink/minichlink.h
@@ -166,6 +166,7 @@ struct InternalState
 	uint32_t target_chip_id;
 	uint8_t flash_sector_status[MAX_FLASH_SECTORS];  // 0 means unerased/unknown. 1 means erased.
 	int nr_registers_for_debug; // Updated by PostSetupConfigureInterface
+	uint8_t isp_xor_key[8];
 };
 
 

--- a/minichlink/pgm-wch-isp.c
+++ b/minichlink/pgm-wch-isp.c
@@ -11,8 +11,8 @@
  * All commands here are "inspired" by https://github.com/wagiminator/MCU-Flash-Tools/blob/main/chprog.py
  * but Wagiminator is awesome so it's ok. (To the best of my knowledge that's the license)
  *************************/
-#define WCH_XOR_KEY_LEN     8
-#define WCH_UID_LEN         8
+#define WCH_XOR_KEY_LEN_8   8
+#define WCH_UID_LEN_8       8
 #define WCH_USB_EP_OUT      0x02
 #define WCH_USB_EP_IN       0x82
 #define WCH_USB_TIMEOUT     5000
@@ -110,8 +110,8 @@ int ISPSetupInterface( void * d ) {
 	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)d)->internal);
 	uint8_t rbuff[1024];
 	uint8_t chip_type = 0;
-	uint8_t uid[WCH_UID_LEN];
-	uint8_t xor_key[WCH_XOR_KEY_LEN];
+	uint8_t uid[WCH_UID_LEN_8];
+	uint8_t xor_key[WCH_XOR_KEY_LEN_8];
 	uint32_t transferred = 0;
 
 	// request chip id
@@ -120,6 +120,10 @@ int ISPSetupInterface( void * d ) {
 		// printf("id response: %02x %02x %02x %02x %02x %02x\n", rbuff[0], rbuff[1], rbuff[2], rbuff[3], rbuff[4], rbuff[5]);
 		chip_type = rbuff[4];
 		printf("chip type: ch5%02x\n", chip_type);
+		if(chip_type != 0x82 && chip_type != 0x92) {
+			printf("ERROR: ISP programming is currently only supported on ch582 and ch59x.\n");
+			return -1;
+		}
 	}
 	else {
 		printf("ERROR: Request Chip ID failed.\n");
@@ -129,10 +133,10 @@ int ISPSetupInterface( void * d ) {
 	// read config
 	wch_isp_command( dev, "\xa7\x02\x00\x1f\x00", 5, (int*)&transferred, rbuff, 1024 );
 	if(transferred == 30) {
-		printf("config: %02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x\n", rbuff[6], rbuff[7], rbuff[8], rbuff[9], rbuff[10], rbuff[11], rbuff[12], rbuff[13], rbuff[14], rbuff[15], rbuff[16], rbuff[17]);
-		printf("bootloader: v%d.%d.%d\n", rbuff[19], rbuff[20], rbuff[21]);
+		printf("config: %02x%02x%02x%02x%02x%02x%02x%02x %02x%02x%02x%02x\n", rbuff[6], rbuff[7], rbuff[8], rbuff[9], rbuff[10], rbuff[11], rbuff[12], rbuff[13], rbuff[14], rbuff[15], rbuff[16], rbuff[17]);
+		printf("bootloader: v%d.%d%d\n", rbuff[19], rbuff[20], rbuff[21]);
 		printf("chip uid: %02x %02x %02x %02x %02x %02x %02x %02x\n", rbuff[22], rbuff[23], rbuff[24], rbuff[25], rbuff[26], rbuff[27], rbuff[28], rbuff[29]);
-		memcpy(uid, &rbuff[22], WCH_UID_LEN);
+		memcpy(uid, &rbuff[22], WCH_UID_LEN_8);
 	}
 	else {
 		printf("ERROR: Read config failed.\n");
@@ -141,18 +145,18 @@ int ISPSetupInterface( void * d ) {
 
 	// create local encryption key
 	uint8_t sum = 0;
-	for(int i = 0; i < WCH_UID_LEN; i++) {
+	for(int i = 0; i < WCH_UID_LEN_8; i++) {
 		sum += uid[i];
 	}
-	for(int i = 0; i < WCH_XOR_KEY_LEN -1; i++) {
+	for(int i = 0; i < WCH_XOR_KEY_LEN_8 -1; i++) {
 		xor_key[i] = sum;
 	}
-	xor_key[WCH_XOR_KEY_LEN -1] = sum + chip_type;
+	xor_key[WCH_XOR_KEY_LEN_8 -1] = sum + chip_type;
 	// printf("encryption key: %02x %02x %02x %02x %02x %02x %02x %02x\n", xor_key[0], xor_key[1], xor_key[2], xor_key[3], xor_key[4], xor_key[5], xor_key[6], xor_key[7]);
 
 	// send encryption key
 	sum = 0;
-	for(int i = 0; i < WCH_XOR_KEY_LEN; i++) {
+	for(int i = 0; i < WCH_XOR_KEY_LEN_8; i++) {
 		sum += xor_key[i];
 	}
 	wch_isp_command( dev, "\xa3\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 33, (int*)&transferred, rbuff, 1024 );
@@ -160,23 +164,95 @@ int ISPSetupInterface( void * d ) {
 		printf("ERROR: Failed to set encryption key.\n");
 		return -3;
 	}
-	memcpy(iss->isp_xor_key, xor_key, WCH_XOR_KEY_LEN);
+	memcpy(iss->isp_xor_key, xor_key, WCH_XOR_KEY_LEN_8);
 
 	return 0;
 }
 
-int ISPWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob_size, const uint8_t * blob ) {
-	fprintf( stderr, "ISPWriteBinaryBlob\n" );
+int ISPErase( void * d, uint32_t address, uint32_t length, int type ) {
+	libusb_device_handle * dev = ((struct ISPProgrammerStruct*)d)->devh;
+	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)d)->internal);
+	uint8_t cmd[7] = {0};
+	uint8_t rbuff[1024];
+	uint32_t transferred = 0;
+
+	if(type == 1) {
+		// whole flash erase, not implemented yet (it does a minimal erase currently)
+		address = 0;
+		length = iss->flash_size; // NOTE: this is the part that is not implemented yet, should be done in ISPSetupInterface
+	}
+
+	uint32_t size = (length +1023) / 1024;
+	size = (size < 8) ? 8 : size;
+
+	cmd[0] = '\xa4';
+	cmd[1] = '\x04';
+	cmd[3] = (uint8_t)size;
+	cmd[4] = (uint8_t)(size >> 8);
+	// printf("erase cmd: %02x%02x%02x%02x%02x%02x%02x\n", cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6]);
+	wch_isp_command( dev, cmd, sizeof(cmd), (int*)&transferred, rbuff, 1024 );
+	if(rbuff[4]) {
+		printf("ERROR: Failed to erase chip.\n");
+		return -2;
+	}
+
 	return 0;
 }
 
-int ISPHaltMode( void * dev, int mode ) {
-	fprintf( stderr, "ISPHaltMode %d\n", mode );
+int ISPWriteBinaryBlob( void * d, uint32_t address_to_write, uint32_t blob_size, const uint8_t * blob ) {
+	libusb_device_handle * dev = ((struct ISPProgrammerStruct*)d)->devh;
+	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)d)->internal);
+	uint8_t stream[3+5+56] = {0}; // 3 byte cmd, 5 byte header, 56 byte chunk
+	uint32_t offset = 0;
+	uint8_t rbuff[1024];
+	uint32_t transferred = 0;
+
+	if(WCH_XOR_KEY_LEN_8 != 8) {
+		printf("ERROR: Only XOR key length of 8 is implemented.\n");
+		return -1;
+	}
+
+	// erase flash
+	ISPErase(d, address_to_write, blob_size, /*type=*/0);
+
+	// write new blob
+	stream[0] = '\xa5';
+	stream[1] = 56 + 5; // packet length, 56 byte chunk + 5 byte header
+	stream[2] = '\x00';
+
+	for(int i = 0; i < ((blob_size / 56) +1); i++) {
+		for(int j = 0; j < 7; j++) { // xor key length means 7 blocks per 56 byte chunk
+			for(int k = 0; k < WCH_XOR_KEY_LEN_8; k++) { // i,j,k for loop I feel like I'm back in Java 101
+				uint32_t blob_idx = (i*56) + (j*8) + k;
+				stream[(3+5) + (j*8) + k] = (blob_idx < blob_size ? blob[blob_idx] : 0xff) ^ iss->isp_xor_key[k];
+			}
+		}
+		offset = i * 56;
+		memcpy(&stream[3], &offset, 4);
+		stream[7] = (uint8_t)(blob_size -(i*56));
+		wch_isp_command( dev, stream, sizeof(stream), (int*)&transferred, rbuff, 1024 );
+		if(rbuff[4] != 0x00 && rbuff[4] != 0xfe && rbuff[4] != 0xf5) {
+			printf("ERROR: Failed to write at offset %d.\n", offset);
+			return -1;
+		}
+	}
+
 	return 0;
 }
 
-void * TryInit_WCHISP()
-{
+int ISPHaltMode( void * d, int mode ) {
+	libusb_device_handle * dev = ((struct ISPProgrammerStruct*)d)->devh;
+	uint8_t rbuff[1024];
+	uint32_t transferred = 0;
+
+	if(mode == HALT_MODE_REBOOT) {
+		wch_isp_command( dev, "\xa2\x01\x00\x01", 4, (int*)&transferred, rbuff, 1024 );
+		printf("Rebooting...\n");
+	}
+	return 0;
+}
+
+void * TryInit_WCHISP() {
 	libusb_device_handle * wch_isp_devh;
 	wch_isp_devh = isp_base_setup(0);
 	if( !wch_isp_devh ) return 0;
@@ -191,6 +267,7 @@ void * TryInit_WCHISP()
 	MCF.WriteWord = ISPWriteWord;
 
 	MCF.SetupInterface = ISPSetupInterface; // no need
+	MCF.Erase = ISPErase;
 	MCF.WriteBinaryBlob = ISPWriteBinaryBlob;
 	MCF.HaltMode = ISPHaltMode;
 

--- a/minichlink/pgm-wch-isp.c
+++ b/minichlink/pgm-wch-isp.c
@@ -45,7 +45,7 @@ static inline libusb_device_handle * isp_base_setup( int inhibit_startup )
 		libusb_device *device = list[i];
 		struct libusb_device_descriptor desc;
 		int r = libusb_get_device_descriptor(device,&desc);
-		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) { found = device; }
+		if( r == 0 && (desc.idVendor == 0x4348 || desc.idVendor == 0x1a86) && desc.idProduct == 0x55e0) { found = device; }
 	}
 
 	if( !found )
@@ -120,8 +120,8 @@ int ISPSetupInterface( void * d ) {
 		// printf("id response: %02x %02x %02x %02x %02x %02x\n", rbuff[0], rbuff[1], rbuff[2], rbuff[3], rbuff[4], rbuff[5]);
 		chip_type = rbuff[4];
 		printf("chip type: ch5%02x\n", chip_type);
-		if(chip_type != 0x82 && chip_type != 0x92) {
-			printf("ERROR: ISP programming is currently only supported on ch582 and ch59x.\n");
+		if(chip_type != 0x70 && chip_type != 0x72 && chip_type != 0x82 && chip_type != 0x91 && chip_type != 0x92) {
+			printf("ERROR: ISP programming is currently only supported on ch570/2, ch582 and ch59x.\n");
 			return -1;
 		}
 	}

--- a/minichlink/pgm-wch-isp.c
+++ b/minichlink/pgm-wch-isp.c
@@ -7,6 +7,15 @@
 #include "libusb.h"
 #include "minichlink.h"
 
+/*************************
+ * All commands here are "inspired" by https://github.com/wagiminator/MCU-Flash-Tools/blob/main/chprog.py
+ * but Wagiminator is awesome so it's ok. (To the best of my knowledge that's the license)
+ *************************/
+#define WCH_XOR_KEY_LEN     8
+#define WCH_UID_LEN         8
+#define WCH_USB_EP_OUT      0x02
+#define WCH_USB_EP_IN       0x82
+#define WCH_USB_TIMEOUT     5000
 #define WCHCHECK(x) if( (status = x) ) { fprintf( stderr, "Bad USB Operation on " __FILE__ ":%d (%d)\n", __LINE__, status ); exit( status ); }
 
 struct ISPProgrammerStruct
@@ -57,13 +66,114 @@ static inline libusb_device_handle * isp_base_setup( int inhibit_startup )
 	return devh;
 }
 
+void wch_isp_command( libusb_device_handle * devh, const void * command_v, int commandlen, int * transferred, uint8_t * reply, int replymax )
+{
+	uint8_t * command = (uint8_t*)command_v;
+	uint8_t buffer[1024];
+	int got_to_recv = 0;
+	int status;
+	int transferred_local;
+	if( !transferred ) transferred = &transferred_local;
+	status = libusb_bulk_transfer( devh, WCH_USB_EP_OUT, command, commandlen, transferred, WCH_USB_TIMEOUT );
+	if( status ) goto sendfail;
+	got_to_recv = 1;
+	if( !reply )
+	{
+		reply = buffer; replymax = sizeof( buffer );
+	}
+
+//	printf("wch_isp_command send (%d)", commandlen); for(int i = 0; i< commandlen; printf(" %02x",command[i++])); printf("\n");
+
+	status = libusb_bulk_transfer( devh, WCH_USB_EP_IN, reply, replymax, transferred, WCH_USB_TIMEOUT );
+
+//	printf("wch_isp_command reply (%d)", *transferred); for(int i = 0; i< *transferred; printf(" %02x",reply[i++])); printf("\n"); 
+
+	if( status ) goto sendfail;
+	return;
+sendfail:
+	fprintf( stderr, "Error sending WCH command (%s): ", got_to_recv?"on recv":"on send" );
+	int i;
+	for( i = 0; i < commandlen; i++ )
+	{
+		printf( "%02x ", command[i] );
+	}
+	printf( "\n" );
+	exit( status );
+}
+
 int ISPWriteReg32( void * dev, uint8_t reg_7_bit, uint32_t command ) { fprintf( stderr, "ISPWriteReg32\n" ); return 0; }
 int ISPReadReg32( void * dev, uint8_t reg_7_bit, uint32_t * commandresp ) { fprintf( stderr, "ISPReadReg32\n" ); return 0; }
 int ISPWriteWord( void * dev, uint32_t address_to_write, uint32_t data ) { fprintf( stderr, "ISPWriteWord\n" ); return 0; }
 
-int ISPSetupInterface( void * dev ) { fprintf( stderr, "ISP bootloader interface was born ready\n" ); return 0; }
-int ISPWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob_size, const uint8_t * blob ) { fprintf( stderr, "ISPWriteBinaryBlob\n" ); return 0; }
-int ISPHaltMode( void * dev, int mode ) { fprintf( stderr, "ISPHaltMode\n" ); return 0; }
+int ISPSetupInterface( void * d ) {
+	libusb_device_handle * dev = ((struct ISPProgrammerStruct*)d)->devh;
+	struct InternalState * iss = (struct InternalState*)(((struct ProgrammerStructBase*)d)->internal);
+	uint8_t rbuff[1024];
+	uint8_t chip_type = 0;
+	uint8_t uid[WCH_UID_LEN];
+	uint8_t xor_key[WCH_XOR_KEY_LEN];
+	uint32_t transferred = 0;
+
+	// request chip id
+	wch_isp_command( dev, "\xa1\x12\x00\x52\x11MCU ISP & WCH.CN", 21, (int*)&transferred, rbuff, 1024 );
+	if(transferred == 6) {
+		// printf("id response: %02x %02x %02x %02x %02x %02x\n", rbuff[0], rbuff[1], rbuff[2], rbuff[3], rbuff[4], rbuff[5]);
+		chip_type = rbuff[4];
+		printf("chip type: ch5%02x\n", chip_type);
+	}
+	else {
+		printf("ERROR: Request Chip ID failed.\n");
+		return -1;
+	}
+
+	// read config
+	wch_isp_command( dev, "\xa7\x02\x00\x1f\x00", 5, (int*)&transferred, rbuff, 1024 );
+	if(transferred == 30) {
+		printf("config: %02x%02x%02x%02x%02x%02x %02x%02x%02x%02x%02x%02x\n", rbuff[6], rbuff[7], rbuff[8], rbuff[9], rbuff[10], rbuff[11], rbuff[12], rbuff[13], rbuff[14], rbuff[15], rbuff[16], rbuff[17]);
+		printf("bootloader: v%d.%d.%d\n", rbuff[19], rbuff[20], rbuff[21]);
+		printf("chip uid: %02x %02x %02x %02x %02x %02x %02x %02x\n", rbuff[22], rbuff[23], rbuff[24], rbuff[25], rbuff[26], rbuff[27], rbuff[28], rbuff[29]);
+		memcpy(uid, &rbuff[22], WCH_UID_LEN);
+	}
+	else {
+		printf("ERROR: Read config failed.\n");
+		return -2;
+	}
+
+	// create local encryption key
+	uint8_t sum = 0;
+	for(int i = 0; i < WCH_UID_LEN; i++) {
+		sum += uid[i];
+	}
+	for(int i = 0; i < WCH_XOR_KEY_LEN -1; i++) {
+		xor_key[i] = sum;
+	}
+	xor_key[WCH_XOR_KEY_LEN -1] = sum + chip_type;
+	// printf("encryption key: %02x %02x %02x %02x %02x %02x %02x %02x\n", xor_key[0], xor_key[1], xor_key[2], xor_key[3], xor_key[4], xor_key[5], xor_key[6], xor_key[7]);
+
+	// send encryption key
+	sum = 0;
+	for(int i = 0; i < WCH_XOR_KEY_LEN; i++) {
+		sum += xor_key[i];
+	}
+	wch_isp_command( dev, "\xa3\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 33, (int*)&transferred, rbuff, 1024 );
+	if(rbuff[4] != sum) {
+		printf("ERROR: Failed to set encryption key.\n");
+		return -3;
+	}
+	memcpy(iss->isp_xor_key, xor_key, WCH_XOR_KEY_LEN);
+
+	return 0;
+}
+
+int ISPWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob_size, const uint8_t * blob ) {
+	fprintf( stderr, "ISPWriteBinaryBlob\n" );
+	return 0;
+}
+
+int ISPHaltMode( void * dev, int mode ) {
+	fprintf( stderr, "ISPHaltMode %d\n", mode );
+	return 0;
+}
 
 void * TryInit_WCHISP()
 {

--- a/minichlink/pgm-wch-isp.c
+++ b/minichlink/pgm-wch-isp.c
@@ -1,0 +1,88 @@
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include "libusb.h"
+#include "minichlink.h"
+
+#define WCHCHECK(x) if( (status = x) ) { fprintf( stderr, "Bad USB Operation on " __FILE__ ":%d (%d)\n", __LINE__, status ); exit( status ); }
+
+struct ISPProgrammerStruct
+{
+	void * internal;
+	libusb_device_handle * devh;
+	int lasthaltmode; // For non-003 chips
+};
+
+static inline libusb_device_handle * isp_base_setup( int inhibit_startup )
+{
+	libusb_context * ctx = 0;
+	int status;
+	status = libusb_init(&ctx);
+	if (status < 0) {
+		fprintf( stderr, "Error: libusb_init_context() returned %d\n", status );
+		exit( status );
+	}
+	
+	libusb_device **list;
+	ssize_t cnt = libusb_get_device_list(ctx, &list);
+	ssize_t i = 0;
+
+	libusb_device *found = NULL;
+
+	for (i = 0; i < cnt; i++) {
+		libusb_device *device = list[i];
+		struct libusb_device_descriptor desc;
+		int r = libusb_get_device_descriptor(device,&desc);
+		if( r == 0 && desc.idVendor == 0x4348 && desc.idProduct == 0x55e0) { found = device; }
+	}
+
+	if( !found )
+	{
+		return 0;
+	}
+
+	libusb_device_handle * devh;
+	status = libusb_open( found, &devh );
+	if( status )
+	{
+		fprintf( stderr, "Error: couldn't access bootloader (libusb_open() = %d)\n", status );
+		return 0;
+	}
+		
+	WCHCHECK( libusb_claim_interface(devh, 0) );
+
+	return devh;
+}
+
+int ISPWriteReg32( void * dev, uint8_t reg_7_bit, uint32_t command ) { fprintf( stderr, "ISPWriteReg32\n" ); return 0; }
+int ISPReadReg32( void * dev, uint8_t reg_7_bit, uint32_t * commandresp ) { fprintf( stderr, "ISPReadReg32\n" ); return 0; }
+int ISPWriteWord( void * dev, uint32_t address_to_write, uint32_t data ) { fprintf( stderr, "ISPWriteWord\n" ); return 0; }
+
+int ISPSetupInterface( void * dev ) { fprintf( stderr, "ISP bootloader interface was born ready\n" ); return 0; }
+int ISPWriteBinaryBlob( void * dev, uint32_t address_to_write, uint32_t blob_size, const uint8_t * blob ) { fprintf( stderr, "ISPWriteBinaryBlob\n" ); return 0; }
+int ISPHaltMode( void * dev, int mode ) { fprintf( stderr, "ISPHaltMode\n" ); return 0; }
+
+void * TryInit_WCHISP()
+{
+	libusb_device_handle * wch_isp_devh;
+	wch_isp_devh = isp_base_setup(0);
+	if( !wch_isp_devh ) return 0;
+
+	struct ISPProgrammerStruct * ret = malloc( sizeof( struct ISPProgrammerStruct ) );
+	memset( ret, 0, sizeof( *ret ) );
+	ret->devh = wch_isp_devh;
+	ret->lasthaltmode = 0;
+
+	MCF.WriteReg32 = ISPWriteReg32;
+	MCF.ReadReg32 = ISPReadReg32;
+	MCF.WriteWord = ISPWriteWord;
+
+	MCF.SetupInterface = ISPSetupInterface; // no need
+	MCF.WriteBinaryBlob = ISPWriteBinaryBlob;
+	MCF.HaltMode = ISPHaltMode;
+
+	return ret;
+};


### PR DESCRIPTION
This change package will enable `minichlink` to program chips using their builtin USB bootloader. This is mostly the ch5xx range, and enables only the `-w` write command (and `-b`) using the ISP interface. And the -E erase command.

I think this is really handy if one has to program a lot of new chips, since they don't need to separately enable the debug interface over USB and then flash the firmware, but can just immediately write the firmware.

This is also useful for people not owning a linkE (yet).

A future improvement will be the addition of `FUNCONF_USBDEBUGPRINTF`, which will get a feature to reboot the mcu into the internal bootloader so minichlink can be used like this without reconnecting the USB cable.