### PR TITLE
BLE beacon low power demo

### DIFF
--- a/ch32fun/ch32v20xhw.h
+++ b/ch32fun/ch32v20xhw.h
@@ -8225,6 +8225,19 @@ typedef struct
 #define PD14 62
 #define PD15 63
 
+#define LL_TX_POWER_MINUS_18_DBM       0x01
+#define LL_TX_POWER_MINUS_10_DBM       0x03
+#define LL_TX_POWER_MINUS_5_DBM        0x05
+#define LL_TX_POWER_MINUS_3_DBM        0x07
+#define LL_TX_POWER_0_DBM              0x09
+#define LL_TX_POWER_1_DBM              0x0B
+#define LL_TX_POWER_2_DBM              0x0D
+#define LL_TX_POWER_3_DBM              0x11
+#define LL_TX_POWER_4_DBM              0x15
+#define LL_TX_POWER_5_DBM              0x1B
+#define LL_TX_POWER_6_DBM              0x25
+#define LL_TX_POWER_7_DBM              0x3F
+
 /*
  * This file contains various parts of the official WCH EVT Headers which
  * were originally under a restrictive license.

--- a/ch32fun/ch57xhw.h
+++ b/ch32fun/ch57xhw.h
@@ -1801,6 +1801,7 @@ RV_STATIC_INLINE void LowPowerSleep(uint32_t cyc, uint16_t power_plan)
   	   R16_POWER_PLAN = RB_PWR_PLAN_EN | RB_PWR_CORE | power_plan | (1<<12);
 	);
 	
+	NVIC->SCTLR &= ~(1 << 3); // wfi
 	asm volatile ("wfi\nnop\nnop" );
 
 	#if ( CLK_SOURCE_CH5XX == CLK_SOURCE_PLL_75MHz ) || ( CLK_SOURCE_CH5XX == CLK_SOURCE_PLL_100MHz )

--- a/ch32fun/ch57xhw.h
+++ b/ch32fun/ch57xhw.h
@@ -1681,6 +1681,24 @@ typedef enum
 #define SLEEP_RTC_MAX_TIME  (RTC_MAX_COUNT - 1000 * 1000 * 30)
 #define WAKE_UP_RTC_MAX_TIME US_TO_RTC(1600)
 
+#define LL_TX_POWER_MINUS_25_DBM       0x01
+#define LL_TX_POWER_MINUS_20_DBM       0x02
+#define LL_TX_POWER_MINUS_15_DBM       0x03
+#define LL_TX_POWER_MINUS_10_DBM       0x05
+#define LL_TX_POWER_MINUS_8_DBM        0x07
+#define LL_TX_POWER_MINUS_5_DBM        0x0A
+#define LL_TX_POWER_MINUS_3_DBM        0x0C
+#define LL_TX_POWER_MINUS_1_DBM        0x10
+#define LL_TX_POWER_0_DBM              0x12
+#define LL_TX_POWER_1_DBM              0x15
+#define LL_TX_POWER_2_DBM              0x18
+#define LL_TX_POWER_3_DBM              0x1B
+#define LL_TX_POWER_4_DBM              0x1F
+#define LL_TX_POWER_5_DBM              0x25
+#define LL_TX_POWER_6_DBM              0x2D
+#define LL_TX_POWER_7_DBM              0x3B
+
+
 RV_STATIC_INLINE void LSIEnable() 
 {
 	SYS_SAFE_ACCESS(

--- a/ch32fun/ch58xhw.h
+++ b/ch32fun/ch58xhw.h
@@ -1501,6 +1501,20 @@ typedef enum
 #define R8_U2EP7_T_LEN      (*((vu8*)0x4000846C))  // USB2 endpoint 7 transmittal length
 #define R8_U2EP7_CTRL       (*((vu8*)0x4000846E))  // USB2 endpoint 7 control
 
+#define LL_TX_POWER_MINUS_16_DBM       0x01
+#define LL_TX_POWER_MINUS_12_DBM       0x02
+#define LL_TX_POWER_MINUS_8_DBM        0x04
+#define LL_TX_POWER_MINUS_5_DBM        0x07
+#define LL_TX_POWER_MINUS_3_DBM        0x09
+#define LL_TX_POWER_MINUS_1_DBM        0x0B
+#define LL_TX_POWER_0_DBM              0x0D
+#define LL_TX_POWER_1_DBM              0x0F
+#define LL_TX_POWER_2_DBM              0x13
+#define LL_TX_POWER_3_DBM              0x17
+#define LL_TX_POWER_4_DBM              0x1D
+#define LL_TX_POWER_5_DBM              0x29
+#define LL_TX_POWER_6_DBM              0x3D
+
 RV_STATIC_INLINE void jump_isprom() {
 	memcpy((void*)ISPROM_IN_RAM_ADDRESS, (void*)(ISPROM_ADDRESS + ISPROM_START_OFFSET), ISPROM_SIZE); // copy bootloader to ram
 	*(int16_t*)(ISPROM_BOOTBUTTON_CHECK_ADDRESS + 0xe) = 0x4505; // li a0, 1, patch PB22 detection to always return true

--- a/ch32fun/ch59xhw.h
+++ b/ch32fun/ch59xhw.h
@@ -1452,6 +1452,20 @@ typedef enum
 #define R8_UEP7_T_LEN       (*((vu8*)0x4000806C))  // endpoint 7 transmittal length
 #define R8_UEP7_CTRL        (*((vu8*)0x4000806E))  // endpoint 7 control
 
+#define LL_TX_POWER_MINUS_20_DBM       0x01
+#define LL_TX_POWER_MINUS_15_DBM       0x03
+#define LL_TX_POWER_MINUS_10_DBM       0x05
+#define LL_TX_POWER_MINUS_8_DBM        0x07
+#define LL_TX_POWER_MINUS_5_DBM        0x0B
+#define LL_TX_POWER_MINUS_3_DBM        0x0F
+#define LL_TX_POWER_MINUS_1_DBM        0x13
+#define LL_TX_POWER_0_DBM              0x15
+#define LL_TX_POWER_1_DBM              0x1B
+#define LL_TX_POWER_2_DBM              0x23
+#define LL_TX_POWER_3_DBM              0x2B
+#define LL_TX_POWER_4_DBM              0x3B
+
+
 RV_STATIC_INLINE void LSIEnable() {
 	SYS_SAFE_ACCESS(
 		R8_CK32K_CONFIG &= ~(RB_CLK_OSC32K_XT | RB_CLK_XT32K_PON); // turn off LSE

--- a/examples_ch5xx/README.md
+++ b/examples_ch5xx/README.md
@@ -4,16 +4,18 @@ The CH5xx examples currently focus on the BLE chips 57x, 58x and 59x, but it is 
 
 The following table details which demo is working on which chip, since some functionality is still being implemented:
 
-|                   | ch570/2 | ch571/3 | ch582/3 | ch584/5 | ch59x |
-|-------------------|---------|---------|---------|---------|-------|
-| blink             |    √    |    √    |    √    |    ×    |   √   |
-| boot_button       |    √    |    ×    |    √    |    ×    |   √   |
-| debugprintfdemo   |    √    |    √    |    √    |    ×    |   √   |
-| iSLER             |    √    |    √    |    √    |    ×    |   √   |
-| lowpower          |    √    |    ×    |    ×    |    ×    |   √   |
-| RTC_irq           |    √    |    √    |    ×    |    ×    |   √   |
-| systick_irq       |    √    |    ×    |    √    |    ×    |   √   |
-| uartdemo          |    √    |    √    |    √    |    ×    |   √   |
-| ws2812bdemo       |    √    |    √    |    √    |    ×    |   √   |
+|                     | ch570/2 | ch571/3 | ch582/3 | ch584/5 | ch59x |
+|---------------------|---------|---------|---------|---------|-------|
+| blink               |    √    |    √    |    √    |    ×    |   √   |
+| ble_beacon          |    √    |    ×    |    ×    |    ×    |   ×   |
+| boot_button         |    √    |    ×    |    √    |    ×    |   √   |
+| comparator_adc_demo |    √    |    ×    |    ×    |    ×    |   ×   |
+| debugprintfdemo     |    √    |    √    |    √    |    ×    |   √   |
+| iSLER               |    √    |    √    |    √    |    ×    |   √   |
+| lowpower            |    √    |    ×    |    ×    |    ×    |   √   |
+| RTC_irq             |    √    |    √    |    ×    |    ×    |   √   |
+| systick_irq         |    √    |    ×    |    √    |    ×    |   √   |
+| uartdemo            |    √    |    √    |    √    |    ×    |   √   |
+| ws2812bdemo         |    √    |    √    |    √    |    ×    |   √   |
 
 The Makefiles default to ch570, if you want to compile for another chip only the `TARGET_MCU` and `TARGET_MCU_PACKAGE` need to be changed.

--- a/examples_ch5xx/README.md
+++ b/examples_ch5xx/README.md
@@ -7,7 +7,7 @@ The following table details which demo is working on which chip, since some func
 |                     | ch570/2 | ch571/3 | ch582/3 | ch584/5 | ch59x |
 |---------------------|---------|---------|---------|---------|-------|
 | blink               |    √    |    √    |    √    |    ×    |   √   |
-| ble_beacon          |    √    |    ×    |    ×    |    ×    |   ×   |
+| ble_beacon          |    √    |    ×    |    ×    |    ×    |   √   |
 | boot_button         |    √    |    ×    |    √    |    ×    |   √   |
 | comparator_adc_demo |    √    |    ×    |    ×    |    ×    |   ×   |
 | debugprintfdemo     |    √    |    √    |    √    |    ×    |   √   |

--- a/examples_ch5xx/ble_beacon/Makefile
+++ b/examples_ch5xx/ble_beacon/Makefile
@@ -1,0 +1,10 @@
+all : flash
+
+TARGET:=ble_beacon
+TARGET_MCU:=CH570
+TARGET_MCU_PACKAGE:=CH32570D
+
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean

--- a/examples_ch5xx/ble_beacon/Makefile
+++ b/examples_ch5xx/ble_beacon/Makefile
@@ -2,7 +2,7 @@ all : flash
 
 TARGET:=ble_beacon
 TARGET_MCU:=CH570
-TARGET_MCU_PACKAGE:=CH32570D
+TARGET_MCU_PACKAGE:=CH570D
 
 include ../../ch32fun/ch32fun.mk
 

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -1,0 +1,52 @@
+#include "ch32fun.h"
+#include "iSLER.h"
+#include <stdio.h>
+
+#ifdef CH570_CH572 // this comes from iSLER.h
+#define LED PA9
+#else
+#define LED PA8
+#endif
+
+#define SLEEPTIME_MS 300
+
+uint8_t adv[] = {0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // MAC (reversed)
+				 0x03, 0x19, 0x00, 0x00, // 0x19: "Appearance", 0x00, 0x00: "Unknown"
+				 0x08, 0x09, 'c', 'h', '3', '2', 'f', 'u', 'n'}; // 0x09: "Complete Local Name"
+uint8_t adv_channels[] = {37,38,39};
+
+void blink(int n) {
+	for(int i = n-1; i >= 0; i--) {
+		funDigitalWrite( LED, FUN_LOW ); // Turn on LED
+		Delay_Ms(33);
+		funDigitalWrite( LED, FUN_HIGH ); // Turn off LED
+		if(i) Delay_Ms(33);
+	}
+}
+
+int main()
+{
+	SystemInit();
+
+	funGpioInitAll();
+	funPinMode( LED, GPIO_CFGLR_OUT_2Mhz_PP );
+
+	RFCoreInit(LL_TX_POWER_0_DBM);
+
+	blink(5);
+	printf(".~ ch32fun BLE beacon ~.\n");
+
+	for(int c = 0; c < sizeof(adv_channels); c++) {
+		Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
+	}
+
+	while(1) {
+		blink(1);
+		for(int c = 0; c < sizeof(adv_channels); c++) {
+			Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
+		}
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K | RB_PWR_EXTEND | RB_XT_PRE_EN) );
+		RFWakeup();
+		DCDCEnable();
+	}
+}

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -15,38 +15,45 @@ uint8_t adv[] = {0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // MAC (reversed)
 				 0x08, 0x09, 'c', 'h', '3', '2', 'f', 'u', 'n'}; // 0x09: "Complete Local Name"
 uint8_t adv_channels[] = {37,38,39};
 
+__attribute__((interrupt))
+void RTC_IRQHandler(void) {
+	// clear trigger flag
+	R8_RTC_FLAG_CTRL = RB_RTC_TRIG_CLR;
+}
+
 void blink(int n) {
 	for(int i = n-1; i >= 0; i--) {
 		funDigitalWrite( LED, FUN_LOW ); // Turn on LED
-		Delay_Ms(33);
+		LowPowerIdle( MS_TO_RTC(33) );
 		funDigitalWrite( LED, FUN_HIGH ); // Turn off LED
-		if(i) Delay_Ms(33);
+		if(i) LowPowerIdle( MS_TO_RTC(33) );
 	}
 }
 
-int main()
-{
+int main() {
 	SystemInit();
+
+	DCDCEnable(); // Enable the internal DCDC
+	LSIEnable(); // Disable LSE, enable LSI
+	RTCInit(); // Set the RTC counter to 0
+	SleepInit(); // Enable wakeup from sleep by RTC, and enable RTC IRQ
 
 	funGpioInitAll();
 	funPinMode( LED, GPIO_CFGLR_OUT_2Mhz_PP );
 
-	RFCoreInit(LL_TX_POWER_0_DBM);
+	uint8_t txPower = LL_TX_POWER_0_DBM;
+	RFCoreInit(txPower);
 
 	blink(5);
 	printf(".~ ch32fun BLE beacon ~.\n");
 
-	for(int c = 0; c < sizeof(adv_channels); c++) {
-		Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
-	}
-
 	while(1) {
-		blink(1);
 		for(int c = 0; c < sizeof(adv_channels); c++) {
 			Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
 		}
-		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K | RB_PWR_EXTEND | RB_XT_PRE_EN) );
-		RFWakeup();
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K | RB_PWR_EXTEND) );
+		RFWakeup(txPower);
 		DCDCEnable();
+		blink(1);
 	}
 }

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -52,7 +52,7 @@ int main() {
 			Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
 		}
 		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K | RB_PWR_EXTEND) );
-		RFWakeup(txPower);
+		RFCoreInit(txPower);
 		DCDCEnable();
 		blink(1);
 	}

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -51,7 +51,7 @@ int main() {
 		for(int c = 0; c < sizeof(adv_channels); c++) {
 			Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
 		}
-		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K | RB_PWR_EXTEND) );
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM2K | RB_PWR_RAM24K | RB_PWR_EXTEND) ); // PWR_RAM can be optimized
 		RFCoreInit(txPower);
 		DCDCEnable();
 		blink(1);

--- a/examples_ch5xx/ble_beacon/funconfig.h
+++ b/examples_ch5xx/ble_beacon/funconfig.h
@@ -1,0 +1,13 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define FUNCONF_USE_HSI           0 // CH5xx does not have HSI
+#define FUNCONF_USE_HSE           1
+#define CLK_SOURCE_CH5XX          CLK_SOURCE_PLL_60MHz // default so not really needed
+#define FUNCONF_SYSTEM_CORE_CLOCK 60 * 1000 * 1000     // keep in line with CLK_SOURCE_CH5XX
+
+#define FUNCONF_DEBUG_HARDFAULT   0
+#define FUNCONF_USE_CLK_SEC       0
+#define FUNCONF_INIT_ANALOG       0 // ADC is not implemented yet
+
+#endif

--- a/examples_ch5xx/iSLER/iSLER.c
+++ b/examples_ch5xx/iSLER/iSLER.c
@@ -7,7 +7,6 @@
 #else
 #define LED PA8
 #endif
-#define LL_TX_POWER_0_DBM 0x12
 #define PHY_MODE          PHY_1M
 
 #define REPORT_ALL 1

--- a/extralibs/iSLER.h
+++ b/extralibs/iSLER.h
@@ -702,18 +702,6 @@ void RFCoreInit(uint8_t TxPower) {
 	NVIC_EnableIRQ(LLE_IRQn);
 }
 
-void RFWakeup(uint8_t TxPower) {
-#if defined(CH570_CH572)
-	LL->LL1 |= 0x1e;
-	LL->LL21 = 0;
-	LL->INT_EN = 0x20003;
-
-	BB->BB15 = 0x40;
-	BB->BB16 = 0xffff;
-#endif
-	DevInit(TxPower);
-}
-
 void DevSetChannel(uint8_t channel) {
 #ifdef CH571_CH573
 	BB->BB6 = (BB->BB6 & 0xf8ffffff) | 0x4000000;

--- a/extralibs/iSLER.h
+++ b/extralibs/iSLER.h
@@ -702,6 +702,17 @@ void RFCoreInit(uint8_t TxPower) {
 	NVIC_EnableIRQ(LLE_IRQn);
 }
 
+void RFWakeup() {
+#if defined(CH570_CH572)
+	LL->LL1 |= 0x1e;
+	LL->LL21 = 0;
+	LL->INT_EN = 0x20003;
+
+	BB->BB15 = 0x40;
+	BB->BB16 = 0xffff;
+#endif
+}
+
 void DevSetChannel(uint8_t channel) {
 #ifdef CH571_CH573
 	BB->BB6 = (BB->BB6 & 0xf8ffffff) | 0x4000000;

--- a/extralibs/iSLER.h
+++ b/extralibs/iSLER.h
@@ -702,7 +702,7 @@ void RFCoreInit(uint8_t TxPower) {
 	NVIC_EnableIRQ(LLE_IRQn);
 }
 
-void RFWakeup() {
+void RFWakeup(uint8_t TxPower) {
 #if defined(CH570_CH572)
 	LL->LL1 |= 0x1e;
 	LL->LL21 = 0;
@@ -711,6 +711,7 @@ void RFWakeup() {
 	BB->BB15 = 0x40;
 	BB->BB16 = 0xffff;
 #endif
+	DevInit(TxPower);
 }
 
 void DevSetChannel(uint8_t channel) {


### PR DESCRIPTION
This is an example of how to implement a simple low power BLE beacon with iSLER. While both low power and iSLER already worked on many chips, the issue was that after a low power state the RF would not properly wake up anymore.
This change package fixes that as well.