### PR TITLE
fix C in assembler error from string.h, introduced in #645

### DIFF
--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -355,9 +355,9 @@ typedef enum {DISABLE = 0, ENABLE = !DISABLE} FunctionalState;
 typedef enum {RESET = 0, SET = !RESET} FlagStatus, ITStatus;
 
 #define   RV_STATIC_INLINE  static  inline
-#endif // __ASSEMBLER__
 
 #include <string.h> // for memcpy in ch5xx hw.h files
+#endif // ifndef __ASSEMBLER__
 
 #if FUNCONF_ISR_IN_RAM
 	#define VECTOR_HANDLER_SECTION ".data.vector_handler"


### PR DESCRIPTION
I added an include of `string.h` in #645 so the `xhw.h` files have memcpy, but I failed to add the `__ASSEMBER__` guard around it. This PR fixes that, which resolves the issue @orbitalair ran into trying to compile the `demo_gamepad` demo in `rv003usb` with the latest `ch32fun` instead of the submodule.
Thanks to @monte-monte for identifying the culprit.