### PR TITLE
Update ch32fun.mk to erase chip each time make flashes the device

### DIFF
--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -332,7 +332,7 @@ clangd_clean :
 	rm -f compile_commands.json
 	rm -rf .cache
 
-FLASH_COMMAND?=$(MINICHLINK)/minichlink -w $< $(WRITE_SECTION) -b
+FLASH_COMMAND?=$(MINICHLINK)/minichlink -E -w $< $(WRITE_SECTION) -b
 
 .PHONY : $(GENERATED_LD_FILE)
 $(GENERATED_LD_FILE) :


### PR DESCRIPTION
Just add flag for full erase, maybe this could be also done with the make command but i would let that into discussion 