### PR TITLE
Ch582 low power

### DIFF
--- a/examples_ch5xx/README.md
+++ b/examples_ch5xx/README.md
@@ -7,13 +7,13 @@ The following table details which demo is working on which chip, since some func
 |                     | ch570/2 | ch571/3 | ch582/3 | ch584/5 | ch59x |
 |---------------------|---------|---------|---------|---------|-------|
 | blink               |    √    |    √    |    √    |    ×    |   √   |
-| ble_beacon          |    √    |    ×    |    ×    |    ×    |   √   |
+| ble_beacon          |    √    |    ×    |    √    |    ×    |   √   |
 | boot_button         |    √    |    ×    |    √    |    ×    |   √   |
 | comparator_adc_demo |    √    |    ×    |    ×    |    ×    |   ×   |
 | debugprintfdemo     |    √    |    √    |    √    |    ×    |   √   |
 | iSLER               |    √    |    √    |    √    |    ×    |   √   |
-| lowpower            |    √    |    ×    |    ×    |    ×    |   √   |
-| RTC_irq             |    √    |    √    |    ×    |    ×    |   √   |
+| lowpower            |    √    |    ×    |    √    |    ×    |   √   |
+| RTC_irq             |    √    |    √    |    √    |    ×    |   √   |
 | systick_irq         |    √    |    ×    |    √    |    ×    |   √   |
 | uartdemo            |    √    |    √    |    √    |    ×    |   √   |
 | ws2812bdemo         |    √    |    √    |    √    |    ×    |   √   |

--- a/examples_ch5xx/RTC_irq/RTC_irq.c
+++ b/examples_ch5xx/RTC_irq/RTC_irq.c
@@ -1,9 +1,15 @@
 #include "ch32fun.h"
 #include <stdio.h>
 
+#if defined(CH57x) && (MCU_PACKAGE == 0 || MCU_PACKAGE == 2)
 #define LED PA9
+#else
+#define LED PA8
+#endif
 
-void RTC_IRQHandler(void) __attribute__((interrupt));
+#define SLEEPTIME_MS 333
+
+__attribute__((interrupt))
 void RTC_IRQHandler(void)
 {
 	// clear timer and trigger flags
@@ -15,7 +21,7 @@ void RTC_IRQHandler(void)
 	// Set a trigger again.
 	// The TMR function of the RTC can also be used for this,
 	// but like this the demo basically shows both
-	RTCTrigger( MS_TO_RTC(333) );
+	RTCTrigger( MS_TO_RTC(SLEEPTIME_MS) );
 }
 
 
@@ -23,7 +29,10 @@ int main(void)
 {
 	SystemInit();
 
-	RTCInit(); // initialize RTC count to 0
+	RTCInit(); // initialize RTC count to 0	
+	SYS_SAFE_ACCESS(
+		R8_RTC_MODE_CTRL |= RB_RTC_TRIG_EN; // enable RTC interrupt trigger
+	);
 	NVIC_EnableIRQ(RTC_IRQn); // enable RTC IRQ to hit the RTC_IRQHandler
 
 	funGpioInitAll(); // no-op on ch5xx
@@ -31,7 +40,7 @@ int main(void)
 	funPinMode(LED, GPIO_CFGLR_OUT_2Mhz_PP);
 
 	// set RTC IRQ trigger to hit the RTC_IRQHandler, in specified amount of RTC ticks
-	RTCTrigger( MS_TO_RTC(333) );
+	RTCTrigger( MS_TO_RTC(SLEEPTIME_MS) );
 
 	while(1);
 }

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -21,6 +21,18 @@ void RTC_IRQHandler(void) {
 	R8_RTC_FLAG_CTRL = RB_RTC_TRIG_CLR;
 }
 
+void allPinPullUp(void)
+{
+	R32_PA_DIR = 0; //Direction input
+	R32_PA_PD_DRV = 0; //Disable pull-down
+	R32_PA_PU = P_All; //Enable pull-up
+#ifdef PB
+	R32_PB_DIR = 0; //Direction input
+	R32_PB_PD_DRV = 0; //Disable pull-down
+	R32_PB_PU = P_All; //Enable pull-up
+#endif
+}
+
 void blink(int n) {
 	for(int i = n-1; i >= 0; i--) {
 		funDigitalWrite( LED, FUN_LOW ); // Turn on LED
@@ -37,6 +49,8 @@ int main() {
 	LSIEnable(); // Disable LSE, enable LSI
 	RTCInit(); // Set the RTC counter to 0
 	SleepInit(); // Enable wakeup from sleep by RTC, and enable RTC IRQ
+
+	allPinPullUp(); // this reduces sleep from ~70uA to 1uA
 
 	funGpioInitAll();
 	funPinMode( LED, GPIO_CFGLR_OUT_2Mhz_PP );

--- a/examples_ch5xx/ble_beacon/ble_beacon.c
+++ b/examples_ch5xx/ble_beacon/ble_beacon.c
@@ -9,6 +9,7 @@
 #endif
 
 #define SLEEPTIME_MS 300
+#define RB_PWR_RAM_MAIN 0x10 // RB_PWR_RAM16K for ch570/2, RB_PWR_RAM30K for ch582/3, RB_PWR_RAM24K for ch59x
 
 uint8_t adv[] = {0x66, 0x55, 0x44, 0x33, 0x22, 0x11, // MAC (reversed)
 				 0x03, 0x19, 0x00, 0x00, // 0x19: "Appearance", 0x00, 0x00: "Unknown"
@@ -65,7 +66,7 @@ int main() {
 		for(int c = 0; c < sizeof(adv_channels); c++) {
 			Frame_TX(adv, sizeof(adv), adv_channels[c], PHY_1M);
 		}
-		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM2K | RB_PWR_RAM24K | RB_PWR_EXTEND) ); // PWR_RAM can be optimized
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM2K | RB_PWR_RAM_MAIN | RB_PWR_EXTEND) ); // PWR_RAM can be optimized
 		RFCoreInit(txPower);
 		DCDCEnable();
 		blink(1);

--- a/examples_ch5xx/lowpower/lowpower.c
+++ b/examples_ch5xx/lowpower/lowpower.c
@@ -57,11 +57,11 @@ int main()
 	uint8_t i = 5;
 	while(i--)
 	{ 
-		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K) );
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM2K) );
 		DCDCEnable();
 		blink_led(2);
 		
-		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM12K) );
+		LowPower( MS_TO_RTC(SLEEPTIME_MS), (RB_PWR_RAM2K) );
 		DCDCEnable();
 		blink_led(3);
 	}

--- a/examples_ch5xx/lowpower/lowpower.c
+++ b/examples_ch5xx/lowpower/lowpower.c
@@ -1,7 +1,12 @@
 #include "ch32fun.h"
 #include <stdio.h>
 
+#if defined(CH57x) && (MCU_PACKAGE == 0 || MCU_PACKAGE == 2)
 #define LED PA9
+#else
+#define LED PA8
+#endif
+
 #define LED_ON FUN_LOW
 #define LED_OFF FUN_HIGH
 #define SLEEPTIME_MS 1000
@@ -11,15 +16,18 @@ void RTC_IRQHandler(void)
 {
 	// clear trigger flag
 	R8_RTC_FLAG_CTRL =  RB_RTC_TRIG_CLR;
-
 }
 
 void allPinPullUp(void)
 {
 	R32_PA_DIR = 0; //Direction input
 	R32_PA_PD_DRV = 0; //Disable pull-down
-	R32_PA_PU = 0xFFFFFFFF; //Enable pull-up  
-	
+	R32_PA_PU = P_All; //Enable pull-up
+#ifdef PB
+	R32_PB_DIR = 0; //Direction input
+	R32_PB_PD_DRV = 0; //Disable pull-down
+	R32_PB_PU = P_All; //Enable pull-up
+#endif	
 }
 
 void blink_led(int n) {

--- a/examples_ch5xx/systick_irq/systick_irq.c
+++ b/examples_ch5xx/systick_irq/systick_irq.c
@@ -4,7 +4,12 @@
 // Number of ticks elapsed per millisecond
 #define SYSTICK_ONE_MILLISECOND ((uint32_t)FUNCONF_SYSTEM_CORE_CLOCK / 1000)
 
-#define LED      PA9 // for WeAct boards ch59x,ch58x,ch57x use PA8
+#if defined(CH57x) && (MCU_PACKAGE == 0 || MCU_PACKAGE == 2)
+#define LED PA9
+#else
+#define LED PA8
+#endif
+
 #define INTERVAL 300*SYSTICK_ONE_MILLISECOND
 
 /*


### PR DESCRIPTION
The ch582 does not have the low power functions implemented yet, and thus can't to battery powered BLE beacon yet.
This package implements the RTC irq demo, low power demo and ble beacon demo for this chip, making it one of the best supported chips in the ch5xx line together with ch570/2 and ch59x.