### PR TITLE
minichlink: fix windows build

### DIFF
--- a/minichlink/cmdserver.h
+++ b/minichlink/cmdserver.h
@@ -260,7 +260,7 @@ int CMDPollServer( void * dev )
 		}
 		else if( g_cmdListenMode == 2 )
 		{
-			if( g_cmdServerSocket ) 	close( g_cmdServerSocket );
+			if( g_cmdServerSocket ) 	closesocket( g_cmdServerSocket );
 			g_cmdServerSocket = 0;
 			g_cmdListenMode = 1;
 			CMDListen();


### PR DESCRIPTION
Use the `closesocket` instead of the `close`, thus conform to the `#define closesocket close` macro (line 23) to ensure that consistent socket closing processing is called across platforms.