### PR TITLE
Build all Makefile projects in one job, but still multithreaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,29 +3,30 @@ name: Build CI
 on: [push, pull_request]
 
 jobs:
-  find-examples: # Job that list subdirectories
+  build-all:
     runs-on: ubuntu-latest
-    outputs:
-      dir: ${{ steps.set-dirs.outputs.dir }} # generate output name dir by using inner step output
     steps:
       - uses: actions/checkout@v4
-      - id: set-dirs # Give it an id to handle to get step outputs in the outputs key above
-        run: echo "::set-output name=dir::$(find examples* -maxdepth 2 -name Makefile -print0 |xargs -0 -n 1 dirname | jq -R -s -c 'split("\n")[:-1]')"
-        # Define step output named dir base on ls command transformed to JSON thanks to jq
-  # Build using native Makefile buildsystem
-  makefile-build:
-    needs: [find-examples] # Depends on previous job
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        example: ${{fromJson(needs.find-examples.outputs.dir)}}
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Dependencies
-      run: sudo apt-get update && sudo apt-get install -y build-essential make libnewlib-dev gcc-riscv64-unknown-elf libusb-1.0-0-dev libudev-dev
-    - name: Build ${{ matrix.example }}
-      run: cd ${{ matrix.example }} && make V=1 -j3 $(basename ${{ matrix.example }}.elf) && riscv64-unknown-elf-size $(basename ${{ matrix.example }}.elf)
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          # remove man-db to avoid slow trigger step
+          sudo apt-get -yqq purge man-db || true
+          sudo apt-get install -y --no-install-recommends \
+            build-essential make libnewlib-dev gcc-riscv64-unknown-elf libusb-1.0-0-dev libudev-dev parallel
+
+      - name: Build all examples (max 10 in parallel)
+        run: |
+          set -e
+          find examples* -maxdepth 2 -name Makefile \
+            | parallel -j 10 '
+                dir=$(dirname {});
+                echo "============================"
+                echo "Building example: $dir"
+                echo "============================"
+                (cd "$dir" && make V=1 -j3 "$(basename "$dir").elf" && riscv64-unknown-elf-size "$(basename "$dir").elf")
+            '
   # Build using PlatformIO
   pio-build:
     strategy:


### PR DESCRIPTION
Per Discord request.

Now uses only one CI job to build all Makefile projects instead of the previous 101. Retains fast compile times by using `gnu parallel` to compile multiple Makefile projects at once. Uses 3 threads per Makefile project. Only takes about 36 seconds total.

PlatformIO CI remains untouched.