### PR TITLE
Drop dependency on "expr", add Windows Makefile build to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,19 @@ jobs:
                 echo "============================"
                 (cd "$dir" && make V=1 -j3 "$(basename "$dir").elf" && riscv64-unknown-elf-size "$(basename "$dir").elf")
             '
+  build-all-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install xPack GCC + Make
+        shell: pwsh
+        run: |
+          ./misc/install_xpack_gcc.ps1 -SkipPrompts
+      - name: Build all examples
+        shell: cmd
+        run: |
+          cd build_scripts
+          build_all.cmd
   # Build using PlatformIO
   pio-build:
     strategy:

--- a/.github/workflows/minichlink.yml
+++ b/.github/workflows/minichlink.yml
@@ -165,6 +165,19 @@ jobs:
           tar czf ../../minichlink-macos-universal.tar.gz *
           cd ../..
 
+      - name: Test binaries
+        if: matrix.os == 'macos-latest'
+        run: |
+          echo "ARM64 version:"
+          otool -L dist/arm64/minichlink 
+          dist/arm64/minichlink -h || true
+          echo "Intel version:"
+          otool -L dist/x86_64/minichlink 
+          dist/x86_64/minichlink -h || true
+          echo "Universal version:"
+          otool -L tmp/universal/minichlink 
+          tmp/universal/minichlink -h || true
+
       - uses: actions/upload-artifact@v4
         if: matrix.os == 'macos-latest'
         with:

--- a/.github/workflows/minichlink.yml
+++ b/.github/workflows/minichlink.yml
@@ -165,19 +165,6 @@ jobs:
           tar czf ../../minichlink-macos-universal.tar.gz *
           cd ../..
 
-      - name: Test binaries
-        if: matrix.os == 'macos-latest'
-        run: |
-          echo "ARM64 version:"
-          otool -L dist/arm64/minichlink 
-          dist/arm64/minichlink -h || true
-          echo "Intel version:"
-          otool -L dist/x86_64/minichlink 
-          dist/x86_64/minichlink -h || true
-          echo "Universal version:"
-          otool -L tmp/universal/minichlink 
-          tmp/universal/minichlink -h || true
-
       - uses: actions/upload-artifact@v4
         if: matrix.os == 'macos-latest'
         with:

--- a/misc/install_xpack_gcc.ps1
+++ b/misc/install_xpack_gcc.ps1
@@ -180,6 +180,11 @@ if (-NOT $NoPath)
 		[Environment]::SetEnvironmentVariable('PATH', $NewPATH, $PathScope);
 		Write-Host '  You may need to restart your terminal before you can use xpack gcc.';
 	}
+	# Detect GitHub Actions runner and export for future steps
+    if ($env:GITHUB_ACTIONS -eq 'true') {
+        Write-Host "Detected GitHub Actions runner. Prepending xPack bin to PATH for workflow steps..."
+        Add-Content -Path $env:GITHUB_ENV -Value "PATH=$XpackBinPath`:$env:PATH"
+    }
 }
 
 Write-Host 'Finished!';


### PR DESCRIPTION
* Drops depedency on `$(shell expr '$(PREFIX)-gcc -dumpversion | cut -f1 -d.' \>= 13)` by using Make builtins like `firstword`, `filter` and `if` to achieve the same result
* Surpresses noisy Windows errors when executing `where` on non-installed programms, it would print `INFO: Could not find files for the given pattern(s).` over and over again. (Redirection of stderr to `nul` or `/dev/null` on Linux, leaving stdout intact)
* Adds a native Windows build job that compiles all ch32v003 examples in the `examples/` folder using `make` via `build_scripts/build_all.cmd`
  * uses and thus also tests existing `install_xpack_gcc.ps1` script to install dependencies and setup environment
    * small addition to detect Github runners and add it to the special `$GITHUB_ENV` environment variable too, instead of just `$PATH`  
  * doesn't build any of the other examples folders due to wanting to keep it fast and lean 