### PR TITLE
Provide default Handlers for USBFS CDC_TTY

### DIFF
--- a/ch32fun/ch32fun.c
+++ b/ch32fun/ch32fun.c
@@ -92,8 +92,6 @@ void __libc_init_array(void)
 #include <stdint.h>
 #include <ch32fun.h>
 
-#define WEAK __attribute__((weak))
-
 WEAK int errno;
 
 static int __puts_uart( char *s, int len, void *buf )

--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -299,6 +299,9 @@
 
 #endif
 
+#ifndef WEAK
+#define WEAK __attribute__((weak))
+#endif
 
 #ifdef __cplusplus
  extern "C" {

--- a/extralibs/fsusb.c
+++ b/extralibs/fsusb.c
@@ -965,3 +965,40 @@ static inline int USBFS_SendNAK( int endp, int tx )
 #endif
 	return 0;
 }
+
+#if defined( FUNCONF_USE_USBPRINTF ) && FUNCONF_USE_USBPRINTF
+WEAK int HandleInRequest( struct _USBState *ctx, int endp, uint8_t *data, int len )
+{
+	return 0;
+}
+
+WEAK void HandleDataOut( struct _USBState *ctx, int endp, uint8_t *data, int len )
+{
+	if ( endp == 0 )
+	{
+		ctx->USBFS_SetupReqLen = 0; // To ACK
+	}
+}
+
+WEAK int HandleSetupCustom( struct _USBState *ctx, int setup_code )
+{
+	int ret = -1;
+	if ( ctx->USBFS_SetupReqType & USB_REQ_TYP_CLASS )
+	{
+		switch ( setup_code )
+		{
+			case CDC_SET_LINE_CODING:
+			case CDC_SET_LINE_CTLSTE:
+			case CDC_SEND_BREAK: ret = ( ctx->USBFS_SetupReqLen ) ? ctx->USBFS_SetupReqLen : -1; break;
+			case CDC_GET_LINE_CODING: ret = ctx->USBFS_SetupReqLen; break;
+			default: ret = 0; break;
+		}
+	}
+	else
+	{
+		ret = 0; // Go to STALL
+	}
+	return ret;
+}
+#endif // FUNCONF_USE_USBPRINTF
+


### PR DESCRIPTION
This should simplify the setup.
Questions:
 - should I also check if `FUSB_USER_HANDLERS` is set or will it always be set if `FUNCONF_USE_USBPRINTF` is set?
 - should I modify the cdc_tty example or should I add a new minimal usbprintf example?