### PR TITLE
Access "undocumented" flash on v20x

### DIFF
--- a/ch32fun/ch32fun.ld
+++ b/ch32fun/ch32fun.ld
@@ -2,10 +2,10 @@ ENTRY( InterruptVector )
 
 MEMORY
 {
-#if TARGET_MCU_LD == 0
+#if TARGET_MCU_LD == 0 /* v00x */
 	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 16K
 	RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 2K
-#elif TARGET_MCU_LD == 1
+#elif TARGET_MCU_LD == 1 /* v10x */
 	#if MCU_PACKAGE == 1
 		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
 		RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K
@@ -15,20 +15,23 @@ MEMORY
 	#else
 		#error "Unknown MCU package"
 	#endif
-#elif TARGET_MCU_LD == 2
+#elif TARGET_MCU_LD == 2 /* v20x */
 	#if MCU_PACKAGE == 1
 		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 64K
+		EXT (rx) : ORIGIN = 0x08010000, LENGTH = 192K
 		RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K
 	#elif MCU_PACKAGE == 2
 		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 32K
+		EXT (rx) : ORIGIN = 0x08008000, LENGTH = 224K
 		RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 10K
 	#elif MCU_PACKAGE == 3
 		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 128K
+		EXT (rx) : ORIGIN = 0x08020000, LENGTH = 128K
 		RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 64K
 	#else
 		#error "Unknown MCU package"
 	#endif
-#elif TARGET_MCU_LD == 3
+#elif TARGET_MCU_LD == 3 /* v30x */
 	#if MCU_PACKAGE == 1
 		#if TARGET_MCU_MEMORY_SPLIT == 1
 			FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 224K
@@ -49,7 +52,7 @@ MEMORY
 	#else
 		#error "Unknown MCU package"
 	#endif
-#elif TARGET_MCU_LD == 4
+#elif TARGET_MCU_LD == 4 /* x03x */
 	#if MCU_PACKAGE == 1
 		FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 62K
 		RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K
@@ -265,6 +268,17 @@ SECTIONS
 #else
 		PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));
 #endif
+
+		.storage :
+		{
+			. = ALIGN(4);
+			*(.storage)
+			*(.storage.*)
+			*(.external)
+			*(.external.*)
+			. = ALIGN(4);
+		} >EXT AT>EXT
+
 
 		/DISCARD/ : {
 			*(.note .note.*)

--- a/ch32fun/ch32fun.mk
+++ b/ch32fun/ch32fun.mk
@@ -299,7 +299,8 @@ FILES_TO_COMPILE:=$(SYSTEM_C) $(TARGET).$(TARGET_EXT) $(ADDITIONAL_C_FILES)
 
 $(TARGET).bin : $(TARGET).elf
 	$(PREFIX)-objdump -S $^ > $(TARGET).lst
-	$(PREFIX)-objcopy $(OBJCOPY_FLAGS) -O binary $< $(TARGET).bin
+	$(PREFIX)-objcopy -R .storage  -O binary $< $(TARGET).bin
+	$(PREFIX)-objcopy -j .storage -O binary $< $(TARGET)_ext.bin
 	$(PREFIX)-objcopy -O ihex $< $(TARGET).hex
 
 ifeq ($(OS),Windows_NT)

--- a/examples_v20x/extendedflash/Makefile
+++ b/examples_v20x/extendedflash/Makefile
@@ -1,0 +1,14 @@
+all : flash
+
+TARGET:=extendedflash
+TARGET_MCU:=CH32V208
+TARGET_MCU_PACKAGE:=CH32V208GB
+
+FLASH_COMMAND=$(MINICHLINK)/minichlink -w $(TARGET).bin flash && $(MINICHLINK)/minichlink -w $(TARGET)_ext.bin 0x08020000 -b
+
+include ../../ch32fun/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean
+	rm -f $(TARGET)_ext.bin
+

--- a/examples_v20x/extendedflash/extendedflash.c
+++ b/examples_v20x/extendedflash/extendedflash.c
@@ -1,0 +1,63 @@
+#include "ch32fun.h"
+#include <stdio.h>
+
+typedef size_t ( *TestFunc_t )( size_t );
+
+size_t Benchmark( const char *tag, TestFunc_t func, size_t param )
+{
+	const size_t start = SysTick->CNT;
+	const size_t result = func( param );
+	const size_t end = SysTick->CNT;
+
+	const size_t ticks = end - start;
+
+	printf( "%s@%08X: took %u ticks, result %u\n", tag, (size_t *)func, ticks, result );
+
+	return ticks;
+}
+
+// function placed in slower memory section
+__attribute__( ( section( ".external" ) ) ) size_t Slow( size_t b )
+{
+
+	size_t sum = 0;
+	for ( size_t i = 0; i < b; i++ )
+	{
+		sum += i & 1 ? i : b;
+	}
+
+	return sum;
+}
+
+size_t Fast( size_t b )
+{
+
+	size_t sum = 0;
+	for ( size_t i = 0; i < b; i++ )
+	{
+		sum += i & 1 ? i : b;
+	}
+
+	return sum;
+}
+
+int main()
+{
+	SystemInit();
+
+	WaitForDebuggerToAttach( 10000 );
+
+	const size_t slowTicks = Benchmark( "Slow", Slow, 100000 );
+	const size_t fastTicks = Benchmark( "Fast", Fast, 100000 );
+
+	const size_t ratio = slowTicks * 100 / fastTicks;
+	const size_t inverse = fastTicks * 100 / slowTicks;
+
+	printf( "Slow flash read is %u%% slower or %u%% the speed of fast flash\n", ratio, inverse );
+
+	while ( 1 )
+	{
+		Delay_Ms( 100 );
+	}
+}
+

--- a/examples_v20x/extendedflash/funconfig.h
+++ b/examples_v20x/extendedflash/funconfig.h
@@ -1,0 +1,5 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#endif
+


### PR DESCRIPTION
The flash memory for all v20x is actually a 256k external spi die bonded to the chip. The flash mentioned in the DS is actually the size of the cache that allows no wait access, but the rest of the chip can still be used.
This is still WIP, but I was able to link code into the slower flash and run from it.
Here are some benchmarks that i ran for read only:
```
Slow Flash read 4096 bytes in 35592 ticks
Fast Flash read 4096 bytes in 5634 ticks
Slow flash read is 631% slower or 15% the speed of fast flash
```
and executing from it:
```
Slow@08020000: took 3512525 ticks, result 3205032704
Fast@0000027A: took 137504 ticks, result 3205032704
Slow flash read is 2554% slower or 3% the speed of fast flash
```