### PR TITLE
Fix undeclared printf function usart_dma_rx_circular.c

### DIFF
--- a/examples/usart_dma_rx_circular/usart_dma_rx_circular.c
+++ b/examples/usart_dma_rx_circular/usart_dma_rx_circular.c
@@ -2,6 +2,7 @@
 // Using any terminal, send "toggle\r\n" to control the LED connected to PC7.
 
 #include "ch32fun.h"
+#include <stdio.h>
 
 #define RX_BUF_LEN 16 // size of receive circular buffer
 


### PR DESCRIPTION
Foud in Windows CI

```
usart_dma_rx_circular.c:15:17: error: implicit declaration of function 'printf' [-Wimplicit-function-declaration]
```

github.com/cnlohr/ch32fun/actions/runs/17566943318/job/49895626071