### PR TITLE
Improve i2c_slave documentation, add remap examples

### DIFF
--- a/examples/i2c_slave/README.md
+++ b/examples/i2c_slave/README.md
@@ -8,17 +8,49 @@ The first byte written to the device within a transaction determines the offset 
 
 The example will turn on a LED connected to PA2 when the LSB of register 0 is set to 1 and off when it's set to 0.
 
-## Usage
+# Usage
 
-Initialize the I2C1 SDA and SCL pins you want to use as open-drain outputs:
+## Pin Setup
+
+Caution: CH32V003 only supports I2C on a few specific pins.
+
+Initialize the default I2C1 SDA and SCL pins as open-drain outputs. By default, pins PC1 and PC2 are used.
 ```
 funPinMode(PC1, GPIO_CFGLR_OUT_10Mhz_AF_OD); // SDA
 funPinMode(PC2, GPIO_CFGLR_OUT_10Mhz_AF_OD); // SCL
 ```
 
-For chips other than the CH32V003 you will need to change the pin numbers to the pins corresponding with the I2C1 peripheral. If you want to use the alternative pins for the I2C periperal in addition to configuring the pins you have to configure the chip to use the the alternative pins using the `I2C1_RM` and `I2C1REMAP1` fields of the `AFIO_PCFR1` register.
+For chips other than the CH32V003 you should change the above pin numbers to the pins corresponding with the I2C1 peripheral.
 
-Then initialize the I2C1 peripheral in slave mode using:
+## Alternate Pins
+
+If you want to use alternative pins for the I2C periperal, then you must take an additional step to configure the chip to use one of the 2 alternative pin mappings.
+
+You can do this using the `AFIO_PCFR1_I2C1_HIGH_BIT_REMAP` and `AFIO_PCFR1_I2C1_REMAP` fields of the `AFIO->PCFR1` register.
+
+Remapping examples:
+
+```c++
+// 2 bits [bit 22 and bit 1] of AFIO->PCFR1 register control I2C1 pin remapping on ch32v003
+// [high bit, low bit]
+
+// [0, 0]				default mapping (SCL on pin PC2, SDA on pin PC1)
+// note: you don't need to do this, since it's the defualt:
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;	  // set high bit = 0
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_REMAP;            // set low bit = 0
+
+// [0, 1]:			Remapping option #1 (SCL on pin PD1, SDA on pin PD0)
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 0
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit = 1
+
+// [1, X]:			Remapping option #2 (SCL on pin PC5, SDA on pin PC6)
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 1
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;            // set low bit [ignored / don't care]
+```
+
+## Initialization
+
+Initialize the I2C1 peripheral in slave mode using:
 
 ```
 SetupI2CSlave(0x09, i2c_registers, sizeof(i2c_registers), onWrite, onRead, false);

--- a/examples/i2c_slave/README.md
+++ b/examples/i2c_slave/README.md
@@ -24,28 +24,29 @@ For chips other than the CH32V003 you should change the above pin numbers to the
 
 ## Alternate Pins
 
-If you want to use alternative pins for the I2C periperal, then you must take an additional step to configure the chip to use one of the 2 alternative pin mappings.
+Optional: If you want to use alternative pins for the I2C periperal, then you must take an additional step to configure the chip to use one of the 2 alternative pin mappings.
 
-You can do this using the `AFIO_PCFR1_I2C1_HIGH_BIT_REMAP` and `AFIO_PCFR1_I2C1_REMAP` fields of the `AFIO->PCFR1` register.
+You can do this using the `I2C1_RM` and `I2C1REMAP1` fields of the `AFIO_PCFR1` register.
 
 Remapping examples:
 
 ```c++
-// 2 bits [bit 22 and bit 1] of AFIO->PCFR1 register control I2C1 pin remapping on ch32v003
+// 2 bits [bit 22 and bit 1] of AFIO_PCFR1 register are what control I2C1 pin remapping on ch32v003
 // [high bit, low bit]
+// [I2C1REMAP1, I2C1_RM]
 
 // [0, 0]				default mapping (SCL on pin PC2, SDA on pin PC1)
-// note: you don't need to do this, since it's the defualt:
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;	  // set high bit = 0
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_REMAP;            // set low bit = 0
+// (note: you don't need to do this, since it's the defualt:)
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;	  // set high bit = 0  (I2C1REMAP1)
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_REMAP;            // set low bit = 0   (I2C1_RM)
 
 // [0, 1]:			Remapping option #1 (SCL on pin PD1, SDA on pin PD0)
-AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 0
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit = 1
+AFIO->PCFR1 &= ~AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 0  (I2C1REMAP1)
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit = 1   (I2C1_RM)
 
 // [1, X]:			Remapping option #2 (SCL on pin PC5, SDA on pin PC6)
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;   // set high bit = 1
-AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;            // set low bit [ignored / don't care]
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_HIGH_BIT_REMAP;    // set high bit = 1  (I2C1REMAP1)
+AFIO->PCFR1 |= AFIO_PCFR1_I2C1_REMAP;             // set low bit [ignored / don't care]    (I2C1_RM)
 ```
 
 ## Initialization


### PR DESCRIPTION
I was banging my head against the wall on this getting it working for the first time, decided to add some sample code for the next person.

This adds some examples on how to do the I2C1 remapping in the AFIO_PCFR1 register, using the latest symbols in Ch32fun [which are named differently than the CH32V003 manual].  I have only tested the 2nd example, though it's pretty simple.

Also just made it a little more obvious you can't put I2C on any random pins, you need to pick specific ones.