### PR TITLE
V203 - Fixed invalid CAN Baud rates

### DIFF
--- a/examples_v20x/canbus_network/canbus_network.c
+++ b/examples_v20x/canbus_network/canbus_network.c
@@ -8,6 +8,7 @@
 // These values are calculated based on the system clock clock being 144MHz
 // The print function bellow will print the actual baud rate
 // if the clock or divider is different.
+#if FUNCONF_SYSTEM_CORE_CLOCK == 144000000
 //                       TS1         TS2            BRP
 #define BAUD_25kbps  ((5 << 16) | (4 << 20) | (479 / AHB1_DIV))
 #define BAUD_50kbps  ((5 << 16) | (4 << 20) | (239 / AHB1_DIV))
@@ -17,6 +18,7 @@
 #define BAUD_500kbps ((5 << 16) | (4 << 20) | ( 23 / AHB1_DIV))
 #define BAUD_750kbps ((5 << 16) | (4 << 20) | ( 15 / AHB1_DIV))
 #define BAUD_1Mbps   ((5 << 16) | (4 << 20) | ( 11 / AHB1_DIV))
+#endif
 
 #define STATUS_OK ( CAN_TSTATR_RQCP0 | CAN_TSTATR_TXOK0 )
 

--- a/examples_v20x/canbus_network/canbus_network.c
+++ b/examples_v20x/canbus_network/canbus_network.c
@@ -9,14 +9,14 @@
 // The print function bellow will print the actual baud rate
 // if the clock or divider is different.
 //                       TS1         TS2            BRP
-#define BAUD_25kbps  ((5 << 16) | (4 << 20) | (239 / AHB1_DIV))
-#define BAUD_50kbps  ((5 << 16) | (4 << 20) | (119 / AHB1_DIV))
-#define BAUD_100kbps ((5 << 16) | (4 << 20) | ( 59 / AHB1_DIV))
-#define BAUD_125kbps ((5 << 16) | (4 << 20) | ( 47 / AHB1_DIV))
-#define BAUD_250kbps ((5 << 16) | (4 << 20) | ( 23 / AHB1_DIV))
-#define BAUD_500kbps ((5 << 16) | (4 << 20) | ( 11 / AHB1_DIV))
-#define BAUD_750kbps ((5 << 16) | (4 << 20) | (  7 / AHB1_DIV))
-#define BAUD_1Mbps   ((5 << 16) | (4 << 20) | (  5 / AHB1_DIV))
+#define BAUD_25kbps  ((5 << 16) | (4 << 20) | (479 / AHB1_DIV))
+#define BAUD_50kbps  ((5 << 16) | (4 << 20) | (239 / AHB1_DIV))
+#define BAUD_100kbps ((5 << 16) | (4 << 20) | (119 / AHB1_DIV))
+#define BAUD_125kbps ((5 << 16) | (4 << 20) | ( 95 / AHB1_DIV))
+#define BAUD_250kbps ((5 << 16) | (4 << 20) | ( 47 / AHB1_DIV))
+#define BAUD_500kbps ((5 << 16) | (4 << 20) | ( 23 / AHB1_DIV))
+#define BAUD_750kbps ((5 << 16) | (4 << 20) | ( 15 / AHB1_DIV))
+#define BAUD_1Mbps   ((5 << 16) | (4 << 20) | ( 11 / AHB1_DIV))
 
 #define STATUS_OK ( CAN_TSTATR_RQCP0 | CAN_TSTATR_TXOK0 )
 

--- a/examples_v20x/canbus_network/canbus_network.c
+++ b/examples_v20x/canbus_network/canbus_network.c
@@ -4,18 +4,19 @@
 
 #define AHB1_DIV 1
 
+// CANbps = PCLK1/((TS1+1+TS2+1+1)*(BRP+1)) (Found in CH32FV2x_V3xRM.PDF page 431)
 // These values are calculated based on the system clock clock being 144MHz
 // The print function bellow will print the actual baud rate
 // if the clock or divider is different.
-//                     TS1           TS2            BRP
-#define BAUD_25kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 479 / AHB1_DIV ) )
-#define BAUD_50kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 239 / AHB1_DIV ) )
-#define BAUD_100kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 119 / AHB1_DIV ) )
-#define BAUD_125kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 59 / AHB1_DIV ) )
-#define BAUD_250kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 47 / AHB1_DIV ) )
-#define BAUD_500kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 23 / AHB1_DIV ) )
-#define BAUD_750kbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 11 / AHB1_DIV ) )
-#define BAUD_1Mbps ( ( 5 << 16 ) | ( 4 << 20 ) | ( 7 / AHB1_DIV ) )
+//                       TS1         TS2            BRP
+#define BAUD_25kbps  ((5 << 16) | (4 << 20) | (239 / AHB1_DIV))
+#define BAUD_50kbps  ((5 << 16) | (4 << 20) | (119 / AHB1_DIV))
+#define BAUD_100kbps ((5 << 16) | (4 << 20) | ( 59 / AHB1_DIV))
+#define BAUD_125kbps ((5 << 16) | (4 << 20) | ( 47 / AHB1_DIV))
+#define BAUD_250kbps ((5 << 16) | (4 << 20) | ( 23 / AHB1_DIV))
+#define BAUD_500kbps ((5 << 16) | (4 << 20) | ( 11 / AHB1_DIV))
+#define BAUD_750kbps ((5 << 16) | (4 << 20) | (  7 / AHB1_DIV))
+#define BAUD_1Mbps   ((5 << 16) | (4 << 20) | (  5 / AHB1_DIV))
 
 #define STATUS_OK ( CAN_TSTATR_RQCP0 | CAN_TSTATR_TXOK0 )
 


### PR DESCRIPTION
I was playing around with the can example code and it seemed to work fine. Upon attaching my logic analyzer I noticed that the BAUD_1Mbps setting actually only worked at 750kbps. Upon digging into the datasheet I noticed that 2 different CAN baud rates are specified.

## Baud Rate Calculations in the Datasheet
---
<img width="629" height="176" alt="image" src="https://github.com/user-attachments/assets/cac0038d-89e7-454f-9510-d0259e8da727" />

---

<img width="622" height="309" alt="image" src="https://github.com/user-attachments/assets/03e48487-7cd0-4347-a9b0-5dbbd5a7cf35" />

---

Upon playing around with the values and testing at 1Mbps, i can verify that the bottom equation is the correct equation. I have been able to confirm that it is indeed running at 1Mbps on my Analog Discovery 3 Logic Analyzer.

I have only verifed that the BAUD_1Mbps is the correct speed at 144Mhz on the HSE.
<img width="574" height="160" alt="image" src="https://github.com/user-attachments/assets/b717da3f-3831-472b-8ff9-fd681ed091ac" />
