### PR TITLE
minichlink: fix two stack buffer overflows in the GDB stub

### DIFF
--- a/minichlink/microgdbstub.h
+++ b/minichlink/microgdbstub.h
@@ -388,7 +388,7 @@ void HandleGDBPacket( void * dev, char * data, int len )
 		uint8_t * pl = alloca( length_to_read * 2 );
 		if( RVReadMem( dev, address_to_read, pl, length_to_read ) < 0 )
 			goto err;
-		char * repl = alloca( length_to_read * 2 );
+		char * repl = alloca( length_to_read * 2 + 1 );
 		int i;
 		for( i = 0; i < length_to_read; i++ )
 		{
@@ -549,7 +549,7 @@ void HandleGDBPacket( void * dev, char * data, int len )
 		// Register Read (All regs)
 		int num_regs = RVGetNumRegisters( dev );
 
-		char cts[num_regs*8+1];
+		char cts[(num_regs+1)*8+1];
 		for( i = 0; i < num_regs+1; i++ )
 		{
 			uint32_t regret;


### PR DESCRIPTION
Two reply buffers in `microgdbstub.h` are one string terminator short. Both are
written by `sprintf`, so the last call writes its NUL past the end.

They are harmless with the default `-O0` build, which is why CI has never
caught them. With any optimised build on a distro that enables
`_FORTIFY_SOURCE` by default (Ubuntu/Debian at `-O2`), glibc aborts the
process the moment GDB connects:

```
gdbserver running on port 3333
Connection established to gdbserver backend
*** buffer overflow detected ***: terminated
```

so `minichlink -G` is unusable in any hardened build.

### 1. `g` packet — read all registers

```c
int num_regs = RVGetNumRegisters( dev );   /* GPRs only: 16 on RV32E, 32 on RV32I */

char cts[num_regs*8+1];                    /* room for num_regs fields */
for( i = 0; i < num_regs+1; i++ )          /* but num_regs+1 are written: GPRs + PC */
    sprintf( cts + i * 8, "%08x", ... );
```

`RVGetNumRegisters()` returns `nr_registers_for_debug`, which excludes PC — the
rest of the tree treats PC as the extra one (`pgm-esp32s2-ch32xx.c` iterates
`i < nr_registers_for_debug + 1` and sizes its reply `(nr+1)*5`), and GDB does
expect GPRs+PC: on CH32V003 it asks for 68 bytes = 17 registers.

So the loop is right and the buffer is one register short. The final `sprintf`
writes 9 bytes starting at `cts[num_regs*8]`, where 1 byte remains.

AddressSanitizer:

```
ERROR: AddressSanitizer: dynamic-stack-buffer-overflow
WRITE of size 9
    #3 HandleGDBPacket microgdbstub.h:557
```

### 2. `m` packet — read memory

```c
char * repl = alloca( length_to_read * 2 );   /* no room for the terminator */
for( i = 0; i < length_to_read; i++ )
    sprintf( repl + i * 2, "%02x", pl[i] );   /* last call writes 3 bytes */
SendReplyFull( repl );                        /* consumed as a C string */
```

```
WRITE of size 3
    #3 HandleGDBPacket microgdbstub.h:395
```

### Fix

```diff
-		char * repl = alloca( length_to_read * 2 );
+		char * repl = alloca( length_to_read * 2 + 1 );

-		char cts[num_regs*8+1];
+		char cts[(num_regs+1)*8+1];
```

Both fixes are needed; fixing only the `g` packet still aborts as soon as GDB
reads memory.

### Testing

Built at `-O2 -DNDEBUG` (Ubuntu 24.04, gcc 13.3.0, so `_FORTIFY_SOURCE` active)
against libusb 1.0.29, on top of `6c4dd53`, with a WCH-LinkE 2.12:

| target | ISA | before | after |
|---|---|---|---|
| CH32V003 | RV32E, 16 GPRs | aborts on connect | breakpoint, continue, re-hit, `print`, `x/8xb`, detach |
| CH32V307 | RV32I, 32 GPRs | aborts on connect | same |

Both register counts matter here, since the `g` buffer is sized from them.

Also confirmed the three ways of building:

| flags | result |
|---|---|
| `-O0 -g3` (Makefile default) | works (overflow is silent) |
| `-O2 -DNDEBUG` | **aborts** |
| `-O2 -DNDEBUG -D_FORTIFY_SOURCE=0` | works (overflow is silent) |

`-T`, `-l` and flashing are unaffected — only the GDB stub is involved.

