### PR TITLE
Update linker script for PIOC SRAM on CH32X035.

### DIFF
--- a/ch32fun/ch32fun.ld
+++ b/ch32fun/ch32fun.ld
@@ -345,9 +345,21 @@ SECTIONS
 
 		PROVIDE( end = . );
 
+#if TARGET_MCU_LD == 4 /* x03x */
+		.pioc_sram (ORIGIN(RAM) + LENGTH(RAM) - 0x1000) (NOLOAD) : {
+			. = ALIGN(4);
+			*(.pioc_sram .pioc_sram.*)
+		} >RAM
+		ASSERT(SIZEOF(.pioc_sram) == 0 || SIZEOF(.pioc_sram) == 0x1000,
+			"Error: PIOC_SRAM, if defined, must be exactly 4kB."
+		)
+#endif
+
 #if TARGET_MCU_LD == 11
 		PROVIDE( _v3f_stack = ORIGIN(RAM) + LENGTH(RAM));
 		PROVIDE( _v5f_stack = ORIGIN(DTCM) + LENGTH(DTCM));
+#elif TARGET_MCU_LD == 4 /* x03x */
+		PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM) - SIZEOF(.pioc_sram));
 #else
 		PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));
 #endif
@@ -363,7 +375,6 @@ SECTIONS
 			. = ALIGN(4);
 		} >EXT AT>EXT
 #endif
-
 
 		/DISCARD/ : {
 			*(.note .note.*)


### PR DESCRIPTION
On CH32X035 PIOC code shared the last 4kB of data SRAM with the host. When PIOC is enabled, that region can not be used as stack, which has to be moved down.

To reserve space, anywhere on C code define the array as below. If not defined then space is used for stack as normal.
```
__attribute__((section(".pioc_sram"), aligned(4)))
union PIOC_SRAM_u {
	uint8_t  u8 [4096];
	uint16_t u16[2048];
	uint32_t u32[1024];
} PIOC_SRAM;
```

The one thing I don't quite like is having the extra `#elif` for setting `_eusrstack`... Maybe create a variable like `_sram_end_reserved`, start it from 0, then += to it when needed?